### PR TITLE
Yksikkötestaus ja loggaaminen tilan tarkistukseen

### DIFF
--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -73,6 +73,16 @@
       (= tyyppi "ammatillinentutkintoosittainen")
       "tutkinnon_osia_suorittaneet")))
 
+(defn get-tila [opiskeluoikeus vahvistus-pvm]
+  (let [tilat (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
+        voimassa (reduce
+                   (fn [res next]
+                     (if (>= (compare vahvistus-pvm (:alku next)) 0)
+                       next
+                       (reduced res)))
+                   (sort-by :alku tilat))]
+    (:koodiarvo (:tila voimassa))))
+
 (defn -handleUpdatedOpiskeluoikeus [this event context]
   (log-caller-details-scheduled "handleUpdatedOpiskeluoikeus" event context)
   (let [start-time (System/currentTimeMillis)
@@ -92,14 +102,7 @@
         (do (doseq [opiskeluoikeus opiskeluoikeudet]
               (let [koulustoimija (get-koulutustoimija-oid opiskeluoikeus)
                     vahvistus-pvm (get-vahvistus-pvm opiskeluoikeus)
-                    tilat (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
-                    voimassa (reduce
-                               (fn [res next]
-                                 (if (>= (compare vahvistus-pvm (:alku next)) 0)
-                                   next
-                                   (reduced res)))
-                               (sort-by :alku tilat))
-                    tila (:koodiarvo (:tila voimassa))]
+                    tila (get-tila opiskeluoikeus vahvistus-pvm)]
                 (when (and (some? vahvistus-pvm)
                            (check-organisaatio-whitelist?
                              koulustoimija

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -87,11 +87,11 @@
   (let [tila (get-tila opiskeluoikeus vahvistus-pvm)]
     (if (or (= tila "valmistunut") (= tila "lasna"))
       true
-      (do (log/info "Opiskeluoikeuden "
+      (do (log/info "Opiskeluoikeuden"
                     (:oid opiskeluoikeus)
-                    " (vahvistuspäivämäärä: "
+                    "(vahvistuspäivämäärä: "
                     vahvistus-pvm
-                    ") tila on "
+                    ") tila on"
                     tila
                     ". Odotettu arvo on 'valmistunut' tai 'läsnä'.")
           false))))

--- a/test/oph/heratepalvelu/UpdatedOpiskeluoikeusHandler_test.clj
+++ b/test/oph/heratepalvelu/UpdatedOpiskeluoikeusHandler_test.clj
@@ -53,3 +53,20 @@
                                 :koulutustoimija {:oid "1.2.246.562.10.35751498086"}
                                 :suoritukset [{:suorituskieli {:koodiarvo "FI"}
                                                :tyyppi {:koodiarvo "valma"}}]})))))
+
+(deftest test-get-tila
+  (testing "Get correct tila given opiskeluoikeus and vahvistus-pvm"
+    (is (= (get-tila {:oid "1.2.246.562.15.82039738925"
+                      :koulutustoimija {:oid "1.2.246.562.10.35751498086"}
+                      :suoritukset [{:suorituskieli {:koodiarvo "FI"}
+                                     :tyyppi {:koodiarvo "nayttotutkintoonvalmistavakoulutus"}
+                                     :vahvistus {:päivä "2019-07-24"}}
+                                    {:suorituskieli {:koodiarvo "FI"}
+                                     :tyyppi {:koodiarvo "ammatillinentutkintoosittainen"}
+                                     :vahvistus {:päivä "2019-07-23"}}]
+                      :tila {:opiskeluoikeusjaksot [{:alku "2019-07-24"
+                                                     :tila {:koodiarvo "lasna"}}
+                                                    {:alku "2019-07-23"
+                                                     :tila {:koodiarvo "valmistunut"}}]}}
+                     "2019-07-23")
+           "valmistunut"))))

--- a/test/oph/heratepalvelu/UpdatedOpiskeluoikeusHandler_test.clj
+++ b/test/oph/heratepalvelu/UpdatedOpiskeluoikeusHandler_test.clj
@@ -69,4 +69,18 @@
                                                     {:alku "2019-07-23"
                                                      :tila {:koodiarvo "valmistunut"}}]}}
                      "2019-07-23")
-           "valmistunut"))))
+           "valmistunut"))
+    (is (= (get-tila {:oid "1.2.246.562.15.82039738925"
+                      :koulutustoimija {:oid "1.2.246.562.10.35751498086"}
+                      :suoritukset [{:suorituskieli {:koodiarvo "FI"}
+                                     :tyyppi {:koodiarvo "nayttotutkintoonvalmistavakoulutus"}
+                                     :vahvistus {:päivä "2019-07-24"}}
+                                    {:suorituskieli {:koodiarvo "FI"}
+                                     :tyyppi {:koodiarvo "ammatillinentutkintoosittainen"}
+                                     :vahvistus {:päivä "2019-07-23"}}]
+                      :tila {:opiskeluoikeusjaksot [{:alku "2019-07-24"
+                                                     :tila {:koodiarvo "lasna"}}
+                                                    {:alku "2019-07-23"
+                                                     :tila {:koodiarvo "valmistunut"}}]}}
+                     "2019-07-24")
+           "lasna"))))


### PR DESCRIPTION
Loggaa, jos viestiä ei lähetetä väärän tilan (muu kuin valmistunut tai läsnä) takia. Yksikkötestit on myös luotu. 