### PR TITLE
Parantaa tep handler virheet

### DIFF
--- a/src/oph/heratepalvelu/external/arvo.clj
+++ b/src/oph/heratepalvelu/external/arvo.clj
@@ -234,5 +234,6 @@
                 :body         (generate-string {:tila tila})
                 :as           :json})))
     (catch ExceptionInfo e
+      (log/error "Virhe patch-nippulinkki-metadata -funktiossa")
       (log/error e)
       (throw e))))

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -141,7 +141,7 @@
                   (catch AwsServiceException e
                     (log/error (str "SMS-viestin lähetysvaiheen kantapäivityksessä tapahtui virhe!"))
                     (log/error e)
-                    (throw e))
+                    (:failed c/kasittelytilat))
                   (catch ExceptionInfo e
                     (if (and
                           (> 399 (:status (ex-data e)))
@@ -149,14 +149,14 @@
                       (do
                         (log/error "Client error while sending sms to number " puhelinnumero)
                         (log/error e)
-                        (throw e))
+                        (:failed c/kasittelytilat))
                       (do
                         (log/error "Server error while sending sms to number " puhelinnumero)
                         (log/error e)
-                        (throw e))))
+                        (:failed c/kasittelytilat))))
                   (catch Exception e
                     (log/error "Unhandled exception " e)
-                    (throw e)))))
+                    (:failed c/kasittelytilat)))))
             (try
               (ddb/update-item
                 {:ohjaaja_ytunnus_kj_tutkinto [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -146,21 +146,17 @@
                         (:failed c/kasittelytilat))))
                   (catch AwsServiceException e
                     (log/error (str "SMS-viestin lähetysvaiheen kantapäivityksessä tapahtui virhe!"))
-                    (log/error e)
-                    (:failed c/kasittelytilat))
+                    (log/error e))
                   (catch ExceptionInfo e
                     (if (client-error? e)
                       (do
                         (log/error "Client error while sending sms")
-                        (log/error e)
-                        (:failed c/kasittelytilat))
+                        (log/error e))
                       (do
                         (log/error "Server error while sending sms")
-                        (log/error e)
-                        (:failed c/kasittelytilat))))
+                        (log/error e))))
                   (catch Exception e
-                    (log/error "Unhandled exception " e)
-                    (:failed c/kasittelytilat)))))
+                    (log/error "Unhandled exception " e)))))
             (try
               (ddb/update-item
                 {:ohjaaja_ytunnus_kj_tutkinto [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -31,7 +31,7 @@
            (let [numtype (str (.getNumberType utilobj numberobj))]
              (or (= numtype "FIXED_LINE_OR_MOBILE") (= numtype "MOBILE")))))
     (catch NumberParseException e
-      (log/error "PhoneNumberUtils failed to parse phonenumber " number)
+      (log/error "PhoneNumberUtils failed to parse phonenumber")
       (log/error e)
       false)))
 
@@ -56,7 +56,7 @@
                            ":lahetettynumeroon" [:s puhelinnumero]}}
         (:nippu-table env))
       (catch Exception e
-        (log/error (str "Error in update-status-to-db for " ohjaaja_ytunnus_kj_tutkinto " , " niputuspvm " , " status))
+        (log/error (str "Error in update-status-to-db. Status:" status))
         (throw e)))))
 
 (defn- ohjaaja-puhnro [nippu jaksot]
@@ -89,9 +89,7 @@
       (let [numerot (reduce #(if (some? (:ohjaaja_puhelinnumero %2))
                                (conj %1 (:ohjaaja_puhelinnumero %2))
                                %1) #{} jaksot)]
-        (log/warn "Ei yksiselitteistä ohjaajan puhelinnumeroa "
-                  (:ohjaaja_ytunnus_kj_tutkinto nippu) ","
-                  (:niputuspvm nippu) "," numerot)
+        (log/warn "Ei yksiselitteistä ohjaajan puhelinnumeroa, " (count numerot) " numeroa löydetty")
           (ddb/update-item
             {:ohjaaja_ytunnus_kj_tutkinto [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]
              :niputuspvm                  [:s (:niputuspvm nippu)]}
@@ -151,11 +149,11 @@
                           (> 399 (:status (ex-data e)))
                           (< 500 (:status (ex-data e))))
                       (do
-                        (log/error "Client error while sending sms to number " puhelinnumero)
+                        (log/error "Client error while sending sms")
                         (log/error e)
                         (:failed c/kasittelytilat))
                       (do
-                        (log/error "Server error while sending sms to number " puhelinnumero)
+                        (log/error "Server error while sending sms")
                         (log/error e)
                         (:failed c/kasittelytilat))))
                   (catch Exception e
@@ -173,7 +171,7 @@
                                   ":sms_lahetyspvm" [:s (str (LocalDate/now))]}}
                 (:nippu-table env))
               (catch Exception e
-                (log/error "Virhe sms-lähetystilan päivityksessä nipulle, jonka vastausaika umpeutunut" nippu)
+                (log/error "Virhe sms-lähetystilan päivityksessä nipulle, jonka vastausaika umpeutunut")
                 (log/error e))))))
       (when (< 60000 (.getRemainingTimeInMillis context))
         (recur (ddb/query-items {:sms_kasittelytila [:eq [:s (:ei-lahetetty c/kasittelytilat)]]

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -18,14 +18,18 @@
              [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
               com.amazonaws.services.lambda.runtime.Context] void]])
 
-(defn- valid-number? [number]
+;; Sallii vain numeroita, jotka kirjasto voi luokitella mobiilin tai
+;; mahdollisesti mobiilin (FIXED_LINE_OR_MOBILE) numeroiksi. Jos tämä Lambda
+;; ei tulevaisuudessa hyväksy numeroa, jonka tiedät olevan validi, tarkista,
+;; miten tämä kirjasto luokittelee sen: https://libphonenumber.appspot.com/.
+(defn valid-number? [number]
   (try
     (let [utilobj (PhoneNumberUtil/getInstance)
           numberobj (.parse utilobj number "FI")]
       (and (empty? (filter (fn [x] (Character/isLetter x)) number))
            (.isValidNumber utilobj numberobj)
-           (= (str (.getNumberType utilobj numberobj))
-              "MOBILE")))
+           (let [numtype (str (.getNumberType utilobj numberobj))]
+             (or (= numtype "FIXED_LINE_OR_MOBILE") (= numtype "MOBILE")))))
     (catch NumberParseException e
       (log/error "PhoneNumberUtils failed to parse phonenumber " number)
       (log/error e)

--- a/test/oph/heratepalvelu/tepSmsHandler_test.clj
+++ b/test/oph/heratepalvelu/tepSmsHandler_test.clj
@@ -1,0 +1,16 @@
+(ns oph.heratepalvelu.tepSmsHandler-test
+  (:require [clojure.test :refer :all]
+            [oph.heratepalvelu.tep.tepSmsHandler :as sh]))
+
+(deftest valid-number-test
+  (testing "Funktio valid-number? tunnistaa oikeita ja virheellisiä puhelinnumeroja"
+    (let [fi-phone-number "040 654 3210"
+          fi-phone-number-intl-fmt "040 654 3210"
+          intl-phone-number "+1 517 987 5432"
+          junk-invalid "laksj fdaiu fd098098asdf"
+          unicode-invalid "+358 40 987 6543à"]
+      (is (sh/valid-number? fi-phone-number))
+      (is (sh/valid-number? fi-phone-number-intl-fmt))
+      (is (sh/valid-number? intl-phone-number))
+      (is (not (sh/valid-number? junk-invalid)))
+      (is (not (sh/valid-number? unicode-invalid))))))

--- a/test/oph/heratepalvelu/tepSmsHandler_test.clj
+++ b/test/oph/heratepalvelu/tepSmsHandler_test.clj
@@ -14,3 +14,10 @@
       (is (sh/valid-number? intl-phone-number))
       (is (not (sh/valid-number? junk-invalid)))
       (is (not (sh/valid-number? unicode-invalid))))))
+
+(deftest client-error-test
+  (testing "Funktio client-error? erottaa client erroreja muista HTTP-statuksista"
+    (let [client-error (ex-info "File not found" {:status 404})
+          server-error (ex-info "Internal server error" {:status 503})]
+      (is (sh/client-error? client-error))
+      (is (not (sh/client-error? server-error))))))


### PR DESCRIPTION
EH-1204

* Error handling on parannettu:
   - Erroreja ei enää heitetä Lambdan handlerista
   - Error-tilanteita logataan selkeämmin erityisesti elisa/send-tep-sms -funktiossa
   - Client ja server erroreja erotetaan nyt oikein (ne olivat alun perin toisinpäin)

* Puhelinnumerot hyväksytään myös, jos puhelinnumerokirjasto ei voi päätä, ovatko ne mobiililaitteita vai kiinteitä puhelimia eli FIXED_LINE_OR_MOBILE-tyyppi nyt hyväksytään. Tämä mahdollistaa eräiden ulkomaalaisten puhelimien käytön. 

* Ei enää logata henkilökohtaisia tietoja kuten puhelinnumerot. 