### PR TITLE
EH 1226

### DIFF
--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -449,7 +449,8 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
         code: lambdaCode,
         environment: {
           ...this.envVars,
-          table: jaksotunnusTable.tableName
+          table: jaksotunnusTable.tableName,
+          caller_id: `1.2.246.562.10.00000000001.${id}-OppisopimuksenPerustatDBChanger`
         },
         handler: "oph.heratepalvelu.util.dbChanger::handleDBGetPuuttuvatOppisopimuksenPerustat",
         memorySize: 1024,

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -448,6 +448,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
         runtime: lambda.Runtime.JAVA_8_CORRETTO,
         code: lambdaCode,
         environment: {
+          ...this.envVars,
           table: jaksotunnusTable.tableName
         },
         handler: "oph.heratepalvelu.util.dbChanger::handleDBGetPuuttuvatOppisopimuksenPerustat",

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -441,10 +441,28 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
     //
     // nippuTable.grantReadWriteData(dbChanger);
 
+    const oppisopimuksenPerustatDBChanger = new lambda.Function(
+      this,
+      "oppisopimuksenPerustatDBChanger",
+      {
+        runtime: lambda.Runtime.JAVA_8_CORRETTO,
+        code: lambdaCode,
+        environment: {
+          table: jaksotunnusTable.tableName
+        },
+        handler: "oph.heratepalvelu.util.dbChanger::handleDBGetPuuttuvatOppisopimuksenPerustat",
+        memorySize: 1024,
+        timeout: Duration.seconds(900),
+        tracing: lambda.Tracing.ACTIVE
+      }
+    );
+
+    jaksotunnusTable.grantReadWriteDate(oppisopimuksenPerustatDBChanger);
+
     // IAM
 
     [jaksoHandler, timedOperationsHandler, niputusHandler, emailHandler, emailStatusHandler, tepSmsHandler,
-      SmsMuistutusHandler, EmailMuistutusHandler].forEach(
+      SmsMuistutusHandler, EmailMuistutusHandler, oppisopimuksenPerustatDBChanger].forEach(
         lambdaFunction => {
           lambdaFunction.addToRolePolicy(new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -457,7 +457,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       }
     );
 
-    jaksotunnusTable.grantReadWriteDate(oppisopimuksenPerustatDBChanger);
+    jaksotunnusTable.grantReadWriteData(oppisopimuksenPerustatDBChanger);
 
     // IAM
 

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
                  [org.clojure/data.json "2.3.1"]]
   :managed-dependencies [[software.amazon.awssdk/aws-core "2.10.56"]
                          [io.netty/netty-buffer "4.1.43.Final"]
+                         [fi.vm.sade/scala-cas_2.12 "2.2.2-SNAPSHOT"]
                          [org.slf4j/slf4j-api "1.7.28"]
                          [com.fasterxml.jackson.core/jackson-core "2.10.0"]]
   :aot :all

--- a/src/oph/heratepalvelu/external/ehoks.clj
+++ b/src/oph/heratepalvelu/external/ehoks.clj
@@ -24,6 +24,16 @@
      :body (generate-string data)
      :as :json}))
 
+(defn get-osaamisen-hankkimistapa-by-id [oht-id]
+  (:data
+    (:body
+      (client/get
+        (str (:ehoks-url env) "hoks/osaamisen-hankkimistapa/" oht-id)
+        {:headers {:ticket (cas/get-service-ticket
+                             "/ehoks-virkailija-backend"
+                             "cas-security-check")}
+         :as :json}))))
+
 (defn get-hankintakoulutus-oids [hoks-id]
   (:body
     (client/get

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -187,7 +187,13 @@
                         (not-empty (:tutkinnonosa-nimi herate))
                         (assoc :tutkinnonosa_nimi [:s (:tutkinnonosa-nimi herate)])
                         (some? (:osa-aikaisuus herate))
-                        (assoc :osa_aikaisuus [:n (:osa-aikaisuus herate)]))
+                        (assoc :osa_aikaisuus [:n (:osa-aikaisuus herate)])
+                        (some? (:oppisopimuksen-perusta herate))
+                        (assoc :oppisopimuksen_perusta
+                               [:s (last
+                                     (str/split
+                                       (:oppisopimuksen-perusta herate)
+                                       #"_"))]))
                 {:cond-expr (str "attribute_not_exists(hankkimistapa_id)")}
                 (:jaksotunnus-table env))
               (ddb/put-item

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -96,7 +96,8 @@
                                       (:oppisopimuksen-perusta-koodi-uri oht)
                                       #"_"))]}}
             (:table env)))
-        (catch Exception e (do))))
+        (catch Exception e
+          (log/error (ex-info e)))))
     (when (.hasLastEvaluatedKey resp)
       (recur (scan {:exclusive-start-key (.lastEvaluatedKey resp)
                     :filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})))))

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -79,8 +79,7 @@
                     :expr-attr-vals {":value1" (.build (.s (AttributeValue/builder) "tutkinnon_suorittaneet"))}})))))
 
 (defn -handleDBGetPuuttuvatOppisopimuksenPerustat [this event context]
-  (loop [resp (scan {:filter-expression "oppisopimuksen_perusta = :value1"
-                     :expr-attr-vals {"value1" (.build (.nul (AttributeValue/builder)))}})]
+  (loop [resp (scan {:filter-expression "oppisopimuksen_perusta = NULL"})]
     (doseq [item (map ddb/map-attribute-values-to-vals (.items resp))]
       (try
         (let [oht (ehoks/get-osaamisen-hankkimistapa-by-id (:hankkimistapa_id item))]
@@ -93,5 +92,4 @@
         (catch Exception e (do))))
     (when (.hasLastEvaluatedKey resp)
       (recur (scan {:exclusive-start-key (.lastEvaluatedKey resp)
-                    :filter-expression "oppisopimuksen_perusta = :value1"
-                    :expr-attr-vals {"value1" (.build (.s (AttributeValue/builder)))}})))))
+                    :filter-expression "oppisopimuksen_perusta = NULL"})))))

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -97,7 +97,7 @@
                                       #"_"))]}}
             (:table env)))
         (catch Exception e
-          (log/error (ex-info e)))))
+          (log/error e))))
     (when (.hasLastEvaluatedKey resp)
       (recur (scan {:exclusive-start-key (.lastEvaluatedKey resp)
                     :filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})))))

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -5,6 +5,7 @@
             [oph.heratepalvelu.external.koski :as k]
             [environ.core :refer [env]]
             [clj-time.core :as t]
+            [clojure.string :as s]
             [clojure.tools.logging :as log])
   (:import (software.amazon.awssdk.services.dynamodb.model ScanRequest AttributeValue)))
 
@@ -87,7 +88,11 @@
             {:hankkimistapa_id [:s (:hankkimistapa_id item)]}
             {:update-expr "SET #value1 = :value1"
              :expr-attr-names {"#value1" "oppisopimuksen_perusta"}
-             :expr-attr-vals {":value1" [:s (:oppisopimuksen-perusta oht)]}}
+             :expr-attr-vals {":value1"
+                              [:s (last
+                                    (s/split
+                                      (:oppisopimuksen-perusta-koodi-uri oht)
+                                      #"_"))]}}
             (:table env)))
         (catch Exception e (do))))
     (when (.hasLastEvaluatedKey resp)

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -87,7 +87,7 @@
         (let [oht (ehoks/get-osaamisen-hankkimistapa-by-id (:hankkimistapa_id item))]
           (log/info "Got this OHT: " oht)
           (ddb/update-item
-            {:hankkimistapa_id [:s (:hankkimistapa_id item)]}
+            {:hankkimistapa_id [:n (:hankkimistapa_id item)]}
             {:update-expr "SET #value1 = :value1"
              :expr-attr-names {"#value1" "oppisopimuksen_perusta"}
              :expr-attr-vals {":value1"

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -82,10 +82,8 @@
 (defn -handleDBGetPuuttuvatOppisopimuksenPerustat [this event context]
   (loop [resp (scan {:filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})]
     (doseq [item (map ddb/map-attribute-values-to-vals (.items resp))]
-      (log/info "Processing entry: " (:hankkimistapa_id item))
       (try
         (let [oht (ehoks/get-osaamisen-hankkimistapa-by-id (:hankkimistapa_id item))]
-          (log/info "Got this OHT: " oht)
           (ddb/update-item
             {:hankkimistapa_id [:n (:hankkimistapa_id item)]}
             {:update-expr "SET #value1 = :value1"

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -1,6 +1,7 @@
 (ns oph.heratepalvelu.util.dbChanger
   (:require [oph.heratepalvelu.common :as c]
             [oph.heratepalvelu.db.dynamodb :as ddb]
+            [oph.heratepalvelu.external.ehoks :as ehoks]
             [oph.heratepalvelu.external.koski :as k]
             [environ.core :refer [env]]
             [clj-time.core :as t]
@@ -13,6 +14,9 @@
              [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
               com.amazonaws.services.lambda.runtime.Context] void]
             [^:static handleDBMarkIncorrectSuoritustyypit
+             [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+              com.amazonaws.services.lambda.runtime.Context] void]
+            [^:static handleDBGetPuuttuvatOppisopimuksenPerustat
              [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
               com.amazonaws.services.lambda.runtime.Context] void]])
 
@@ -73,3 +77,9 @@
       (recur (scan {:exclusive-start-key (.lastEvaluatedKey resp)
                     :filter-expression "kyselytyyppi = :value1"
                     :expr-attr-vals {":value1" (.build (.s (AttributeValue/builder) "tutkinnon_suorittaneet"))}})))))
+
+(defn -handleDBGetPuuttuvatOppisopimuksenPerustat [this event context]
+  (loop [resp (scan {:filter-expression "oppisopimuksen_perusta = :value1"
+                     :expr-attr-vals {"value1" (.build (.nul (AttributeValue/builder)))}})]
+    ;; TODO
+    ))

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -82,8 +82,10 @@
 (defn -handleDBGetPuuttuvatOppisopimuksenPerustat [this event context]
   (loop [resp (scan {:filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})]
     (doseq [item (map ddb/map-attribute-values-to-vals (.items resp))]
+      (log/info "Processing entry: " (:hankkimistapa_id item))
       (try
         (let [oht (ehoks/get-osaamisen-hankkimistapa-by-id (:hankkimistapa_id item))]
+          (log/info "Got this OHT: " oht)
           (ddb/update-item
             {:hankkimistapa_id [:s (:hankkimistapa_id item)]}
             {:update-expr "SET #value1 = :value1"

--- a/src/oph/heratepalvelu/util/dbChanger.clj
+++ b/src/oph/heratepalvelu/util/dbChanger.clj
@@ -79,7 +79,7 @@
                     :expr-attr-vals {":value1" (.build (.s (AttributeValue/builder) "tutkinnon_suorittaneet"))}})))))
 
 (defn -handleDBGetPuuttuvatOppisopimuksenPerustat [this event context]
-  (loop [resp (scan {:filter-expression "oppisopimuksen_perusta = NULL"})]
+  (loop [resp (scan {:filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})]
     (doseq [item (map ddb/map-attribute-values-to-vals (.items resp))]
       (try
         (let [oht (ehoks/get-osaamisen-hankkimistapa-by-id (:hankkimistapa_id item))]
@@ -92,4 +92,4 @@
         (catch Exception e (do))))
     (when (.hasLastEvaluatedKey resp)
       (recur (scan {:exclusive-start-key (.lastEvaluatedKey resp)
-                    :filter-expression "oppisopimuksen_perusta = NULL"})))))
+                    :filter-expression "attribute_not_exists(oppisopimuksen_perusta)"})))))


### PR DESCRIPTION
Huomioi oppisopimuksen perusta -tiedot työpaikkajaksojen käsittelyssä, ja lisää myös mahdollisuuden päivittää jo käsiteltyjä jaksoja jälkikäteen. 

Lisätty myös [fi.vm.sade/scala-cas_2.12 "2.2.2-SNAPSHOT"] -rivi project.clj -tiedostoon. 