### PR TITLE
Eh 1228

### DIFF
--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -63,8 +63,7 @@
   (let [tilat (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
         voimassa (reduce
                    (fn [res next]
-                     (if (not (.isBefore (LocalDate/parse loppupvm)
-                                         (.plusDays (LocalDate/parse (:alku next)) 1)))
+                     (if (.isBefore (LocalDate/parse (:alku next)) (LocalDate/parse loppupvm))
                        next
                        (reduced res)))
                    (sort-by :alku tilat))

--- a/test/oph/heratepalvelu/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/jaksoHandler_test.clj
@@ -38,15 +38,15 @@
                                                 {:opiskeluoikeusjaksot [{:alku "2021-06-20" :tila {:koodiarvo "loma"}}
                                                                         {:alku "2021-05-01" :tila {:koodiarvo "lasna"}}
                                                                         {:alku "2021-09-07" :tila {:koodiarvo "eronnut"}}]}}
-          opiskeluoikeus-kesk-eronnut-tulevaisuudessa {:tila
+          opiskeluoikeus-eronnut-tulevaisuudessa {:tila
                                                        {:opiskeluoikeusjaksot [{:alku "2021-06-20" :tila {:koodiarvo "loma"}}
                                                                                {:alku "2021-05-01" :tila {:koodiarvo "lasna"}}
                                                                                {:alku "2021-09-08" :tila {:koodiarvo "eronnut"}}]}}
-          opiskeluoikeus-kesk-eronnut-paivaa-aiemmin {:tila
+          opiskeluoikeus-eronnut-paivaa-aiemmin {:tila
                                                       {:opiskeluoikeusjaksot [{:alku "2021-06-20" :tila {:koodiarvo "loma"}}
                                                                               {:alku "2021-05-01" :tila {:koodiarvo "lasna"}}
                                                                               {:alku "2021-09-06" :tila {:koodiarvo "eronnut"}}]}}]
       (is (= true (jh/check-opiskeluoikeus-tila opiskeluoikeus-lasna loppupvm)))
       (is (= true (jh/check-opiskeluoikeus-tila opiskeluoikeus-eronnut-samana-paivana loppupvm)))
-      (is (= true (jh/check-opiskeluoikeus-tila opiskeluoikeus-kesk-eronnut-tulevaisuudessa loppupvm)))
-      (is (nil? (jh/check-opiskeluoikeus-tila opiskeluoikeus-kesk-eronnut-paivaa-aiemmin loppupvm))))))
+      (is (= true (jh/check-opiskeluoikeus-tila opiskeluoikeus-eronnut-tulevaisuudessa loppupvm)))
+      (is (nil? (jh/check-opiskeluoikeus-tila opiskeluoikeus-eronnut-paivaa-aiemmin loppupvm))))))


### PR DESCRIPTION
Tällä hetkellä työpaikkajaksoa ei käsitellä, mikäli Koskeen on tallennettu opiskeluoikeuden terminaalitila alkamaan työpaikkajakson päättymispäivänä. Esim. jakso päättyy 31.1.2021 ja Koskessa opiskeluoikeuden tila "eronnut" 31.1.2021 ->.

Logiikkaa pitäisi muuttaa siten, että **jaksoa ei käsitellä, mikäli opiskeluoikeuden terminaalitila on tullut voimaan työpaikkajakson päättymistä edeltävänä päivänä**. 