### PR TITLE
Jaksoa ei luoda, jos keskeytynyt viimeisenä päivänä

### DIFF
--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -91,8 +91,8 @@
   (let [kjaksot (sort-process-keskeytymisajanjaksot herate)]
     (or (empty? kjaksot)
         (not (:loppu (last kjaksot)))
-        (not (.isAfter (:loppu (last kjaksot))
-                       (LocalDate/parse (:loppupvm herate)))))))
+        (.isAfter (LocalDate/parse (:loppupvm herate))
+                  (:loppu (last kjaksot))))))
 
 (defn check-open-keskeytymisajanjakso [herate]
   (let [kjaksot (sort-process-keskeytymisajanjaksot herate)]


### PR DESCRIPTION
Ei tallenneta työpaikkajaksoa TEP-kantaan, jos sen viimeisen keskeytymisajanjakson päättymispäivä ja työpaikkajakson loppupäivämäärä ovat samoja. 