### PR TITLE
Poistettu yksi pouli check-organisaatio-whitelist? -funktiota

### DIFF
--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -153,34 +153,22 @@
   (str (normalize-string tyopaikan-nimi) "_" (local-date-now) "_" (rand-str 6)))
 
 (defn check-organisaatio-whitelist?
-  ([koulutustoimija]
-   (let [item (ddb/get-item {:organisaatio-oid [:s koulutustoimija]}
-                            (:orgwhitelist-table env))]
-     (if (.isBefore (LocalDate/of 2021 6 30) (local-date-now))
-       true
-       (if
-         (and
-           (:kayttoonottopvm item)
-           (<= (c/to-long (f/parse (:date f/formatters) (:kayttoonottopvm item)))
-               (c/to-long (local-date-now))))
-         true
-         (log/info "Koulutustoimija " koulutustoimija " ei ole mukana automaatiossa")))))
-  ([koulutustoimija timestamp]
-   (let [item (ddb/get-item {:organisaatio-oid [:s koulutustoimija]}
-                            (:orgwhitelist-table env))]
-     (if (.isBefore (LocalDate/of 2021 6 30) (LocalDate/ofEpochDay (/ timestamp 86400000)))
-       true
-       (if
-         (and
-           (:kayttoonottopvm item)
-           (<= (c/to-long (f/parse (:date f/formatters) (:kayttoonottopvm item)))
-               timestamp)
-           (<= (c/to-long (f/parse (:date f/formatters) (:kayttoonottopvm item)))
-               (c/to-long (local-date-now))))
-         true
-         (log/info "Koulutustoimija " koulutustoimija " ei ole mukana automaatiossa,"
-                   " tai herätepvm " (str (LocalDate/ofEpochDay (/ timestamp 86400000)))
-                   " on ennen käyttöönotto päivämäärää"))))))
+  [koulutustoimija timestamp]
+  (let [item (ddb/get-item {:organisaatio-oid [:s koulutustoimija]}
+                           (:orgwhitelist-table env))]
+    (if (.isBefore (LocalDate/of 2021 6 30) (LocalDate/ofEpochDay (/ timestamp 86400000)))
+      true
+      (if
+        (and
+          (:kayttoonottopvm item)
+          (<= (c/to-long (f/parse (:date f/formatters) (:kayttoonottopvm item)))
+              timestamp)
+          (<= (c/to-long (f/parse (:date f/formatters) (:kayttoonottopvm item)))
+              (c/to-long (local-date-now))))
+        true
+        (log/info "Koulutustoimija " koulutustoimija " ei ole mukana automaatiossa,"
+                  " tai herätepvm " (str (LocalDate/ofEpochDay (/ timestamp 86400000)))
+                  " on ennen käyttöönotto päivämäärää")))))
 
 (defn check-duplicate-herate? [oppija koulutustoimija laskentakausi kyselytyyppi]
   (if

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -306,7 +306,6 @@
                   (and
                     (check-opiskeluoikeus-tila opiskeluoikeus (:loppupvm herate))
                     (check-not-fully-keskeytynyt herate)
-                    (c/check-organisaatio-whitelist? koulutustoimija)
                     (c/check-opiskeluoikeus-suoritus-types? opiskeluoikeus)
                     (c/check-sisaltyy-opiskeluoikeuteen? opiskeluoikeus))
                   (save-jaksotunnus herate opiskeluoikeus koulutustoimija)))))

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -494,12 +494,6 @@
      :herate herate})
   true)
 
-(defn- mock-check-organisaatio-whitelist? [koulutustoimija]
-  (add-to-test-handleJaksoHerate-results
-    {:type "mock-check-organisaatio-whitelist?"
-     :koulutustoimija koulutustoimija})
-  true)
-
 (defn- mock-check-opiskeluoikeus-suoritus-types? [opiskeluoikeus]
   (add-to-test-handleJaksoHerate-results
     {:type "mock-check-opiskeluoikeus-suoritus-types?"
@@ -527,8 +521,6 @@
   (testing "Varmista, että -handleJaksoHerate kutsuu funktioita oikein"
     (with-redefs [oph.heratepalvelu.common/check-opiskeluoikeus-suoritus-types?
                   mock-check-opiskeluoikeus-suoritus-types?
-                  oph.heratepalvelu.common/check-organisaatio-whitelist?
-                  mock-check-organisaatio-whitelist?
                   oph.heratepalvelu.common/check-sisaltyy-opiskeluoikeuteen?
                   mock-check-sisaltyy-opiskeluoikeuteen?
                   oph.heratepalvelu.common/get-koulutustoimija-oid
@@ -564,8 +556,6 @@
                       :herate {:opiskeluoikeus-oid "123.456.789"
                                :loppupvm "2021-12-15"
                                :hankkimistapa-id 12345}}
-                     {:type "mock-check-organisaatio-whitelist?"
-                      :koulutustoimija "mock-koulutustoimija-oid"}
                      {:type "mock-check-opiskeluoikeus-suoritus-types?"
                       :opiskeluoikeus
                       {:oid "123.456.789"

--- a/test/oph/heratepalvelu/test_util.clj
+++ b/test/oph/heratepalvelu/test_util.clj
@@ -125,8 +125,6 @@
 
 (defn mock-check-organisaatio-whitelist-true? [_ _] true)
 
-(defn mock-check-organisaatio-whitelist-false? [_] false)
-
 (defn mock-check-duplicate-herate-true? [_ _ _ _] true)
 
 (defn mock-check-duplicate-herate-false? [_ _ _ _] false)


### PR DESCRIPTION
Jos timestampia ei annettu, check-organisaatio-whitelist? -funktio palautti aina true (ainakin 6.30.2021 jälkeen). Poistin sen noista paikoista, joissa se oli turha.