### PR TITLE
Logitus: WARN > INFO kun AMIS heräte on duplikoitu

### DIFF
--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -225,7 +225,7 @@
                (check-db? "tutkinnon_osia_suorittaneet"))
           (check-db? kyselytyyppi)))
     true
-    (log/warn "Tämän kyselyn linkki on jo toimituksessa oppilaalle "
+    (log/info "Tämän kyselyn linkki on jo toimituksessa oppilaalle "
               oppija " koulutustoimijalla " koulutustoimija
               "(tyyppi '" kyselytyyppi "' kausi " laskentakausi ")")))
 


### PR DESCRIPTION
Koska AMIS-herätteet lähetetään usein monta kertaa (retry-logiikan takia), muutan logituksen näin, että duplikaattiherätteet logitetaan INFO-tasolla, eikä WARN-tasolla. 