### PR TITLE
Kaada AMISherateEmailHandler, jos Arvo on nurin

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -25,36 +25,40 @@
   [herate]
   (if (:kyselylinkki herate)
     herate
-    (try
-      (let [opiskeluoikeus (k/get-opiskeluoikeus-catch-404
-                             (:opiskeluoikeus-oid herate))
-            req-body (arvo/build-arvo-request-body
-                       herate
-                       opiskeluoikeus
-                       (:request-id herate)
-                       (:koulutustoimija herate)
-                       (c/get-suoritus opiskeluoikeus)
-                       (:alkupvm herate)
-                       (:voimassa-loppupvm herate))
-            arvo-resp (if (= (:kyselytyyppi herate) "aloittaneet")
+    (let [opiskeluoikeus (k/get-opiskeluoikeus-catch-404
+                           (:opiskeluoikeus-oid herate))
+          req-body (arvo/build-arvo-request-body
+                     herate
+                     opiskeluoikeus
+                     (:request-id herate)
+                     (:koulutustoimija herate)
+                     (c/get-suoritus opiskeluoikeus)
+                     (:alkupvm herate)
+                     (:voimassa-loppupvm herate))
+          arvo-resp (try
+                      (if (= (:kyselytyyppi herate) "aloittaneet")
                         (arvo/create-amis-kyselylinkki req-body)
-                        (arvo/create-amis-kyselylinkki-catch-404 req-body))]
-        (if-let [kyselylinkki (:kysely_linkki arvo-resp)]
-          (do (ac/update-herate herate {:kyselylinkki [:s kyselylinkki]})
-              (try
-                (ehoks/add-kyselytunnus-to-hoks
-                  (:ehoks-id herate)
-                  {:kyselylinkki kyselylinkki
-                   :tyyppi       (:kyselytyyppi herate)
-                   :alkupvm      (:alkupvm herate)
-                   :lahetystila  (:ei-lahetetty c/kasittelytilat)})
-                (catch Exception e
-                  (log/error "Virhe linkin lähetyksessä eHOKSiin " e)))
-              (assoc herate :kyselylinkki kyselylinkki))
-          (log/error "Kyselylinkkiä ei palautettu Arvosta. Request ID:"
-                     (:request-id herate))))
-      (catch Exception e
-        (log/error "Virhe kyselylinkin hakemisessa Arvosta" e)))))
+                        (arvo/create-amis-kyselylinkki-catch-404 req-body))
+                      (catch Exception e
+                        (log/error "Virhe kyselylinkin hakemisessa Arvosta:" e)
+                        (throw e)))]
+      (if-let [kyselylinkki (:kysely_linkki arvo-resp)]
+        (do (ac/update-herate herate {:kyselylinkki [:s kyselylinkki]})
+            (try
+              (ehoks/add-kyselytunnus-to-hoks
+                (:ehoks-id herate)
+                {:kyselylinkki kyselylinkki
+                 :tyyppi       (:kyselytyyppi herate)
+                 :alkupvm      (:alkupvm herate)
+                 :lahetystila  (:ei-lahetetty c/kasittelytilat)})
+              (catch Exception e
+                (log/error "Virhe linkin lähetyksessä eHOKSiin " e)
+                (throw e)))
+            (assoc herate :kyselylinkki kyselylinkki))
+        (do (log/error "Kyselylinkkiä ei palautettu Arvosta. Request ID:"
+                       (:request-id herate))
+            (throw (ex-info "Kyselylinkkiä ei palautettu Arvosta."
+                            {:request-id (:request-id herate)})))))))
 
 (defn save-email-to-db
   "Tallentaa sähköpostin tiedot tietokantaan, kun sähköposti on lähetetty


### PR DESCRIPTION
Muokkasin virhekäsittelyn näin, että jos Arvo palauttaa virheen, funktio kaatuu. Käytännössä tämä tarkoittaa, että jos Arvo kaatuu ja palauttaa säännöllisesti virheitä, AMISherateEmailHandler yrittää käsitellä vain yhden herätteen joka kerta, kun se herää (5 minuuti välein). Tällä vältetään spämmittämistä muita palveluja, erityisesti CAS.

Vaikka Arvo-kutsut eivät käytä CASia, arvo/build-arvo-request-body tekee joitakin kutsuja muihin palveluihin, mukaan lukien ehoksiin (mikähän käyttää CASia).