### PR TITLE
EH 1196

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                  [environ "1.1.0"]
                  [clj-http "3.10.0"]
                  [cheshire "5.8.1"]
-                 [clj-time "0.15.1"]
                  [com.amazonaws/aws-xray-recorder-sdk-core "2.4.0"]
                  [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2 "2.4.0"]
                  [com.amazonaws/aws-lambda-java-core "1.2.0"]

--- a/src/oph/heratepalvelu/amis/AMISherateHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateHandler.clj
@@ -10,7 +10,8 @@
             [oph.heratepalvelu.log.caller-log :refer :all])
   (:import (com.amazonaws.services.lambda.runtime.events SQSEvent$SQSMessage)
            (com.fasterxml.jackson.core JsonParseException)
-           (clojure.lang ExceptionInfo)))
+           (clojure.lang ExceptionInfo)
+           (java.time Instant)))
 
 (gen-class
   :name "oph.heratepalvelu.amis.AMISherateHandler"
@@ -34,7 +35,8 @@
                   (if (and (check-opiskeluoikeus-suoritus-types? opiskeluoikeus)
                            (check-organisaatio-whitelist?
                              koulutustoimija
-                             (date-string-to-timestamp (:alkupvm herate)))
+                             (Instant/parse (str (:alkupvm herate)
+                                                 "T00:00:00Z")))
                            (check-sisaltyy-opiskeluoikeuteen? opiskeluoikeus))
                     (ac/save-herate herate opiskeluoikeus koulutustoimija)
                     (log/info "Ei tallenneta kantaan"

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -100,12 +100,17 @@
                     ". Odotettu arvo on 'valmistunut' tai 'läsnä'.")
           false))))
 
+(defn- current-time-millis
+  "Hakee nykyisen ajan millisekunneilla."
+  []
+  (c/from-long (System/currentTimeMillis)))
+
 (defn -handleUpdatedOpiskeluoikeus
   "Hakee päivitettyjä opiskeluoikeuksia koskesta ja tallentaa niiden tiedot
   tietokantaan."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleUpdatedOpiskeluoikeus" event context)
-  (let [start-time (c/from-long (System/currentTimeMillis))
+  (let [start-time (current-time-millis)
         last-checked (:value (ddb/get-item
                                {:key [:s "opiskeluoikeus-last-checked"]}
                                (:metadata-table env)))

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -48,7 +48,7 @@
    aloituksen aikoja, joten muutoksien hakuhetken jälkeen tietokantaan voi
    tallentua aikaleimoja menneisyyteen. Hakemalla 1 min bufferilla
    varmistetaan että kaikki muutokset käsitellään vähintään 1 kerran."
-  [datetime]
+  [^Instant datetime]
   (let [time-with-buffer (.minusSeconds datetime 300)]
     (ddb/update-item
       {:key [:s "opiskeluoikeus-last-checked"]}

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -3,6 +3,7 @@
   tietokantaan."
   (:require [clj-time.coerce :as c]
             [clj-time.core :as t]
+            [clojure.string :as s]
             [clojure.tools.logging :as log]
             [environ.core :refer [env]]
             [oph.heratepalvelu.amis.AMISCommon :as ac]
@@ -117,8 +118,13 @@
         last-page (Integer/valueOf
                     ^String (:value (ddb/get-item
                                       {:key [:s "opiskeluoikeus-last-page"]}
-                                      (:metadata-table env))))]
-    (log/info "Käsitellään" last-checked "jälkeen muuttuneet opiskeluoikeudet")
+                                      (:metadata-table env))))
+        get-date #(first (s/split (str %) #"T"))]
+    (log/info "Käsitellään"
+              (get-date last-checked)
+              "ja"
+              (get-date start-time)
+              "välillä päättyneet opiskeluoikeudet")
     (loop [opiskeluoikeudet (k/get-completed-opiskeluoikeudet
                               last-checked
                               start-time

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -1,8 +1,6 @@
 (ns oph.heratepalvelu.common
   "Yhteiset funktiot herätepalvelulle."
-  (:require [clj-time.coerce :as c]
-            [clj-time.format :as f]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
             [environ.core :refer [env]]
             [oph.heratepalvelu.db.dynamodb :as ddb]
@@ -11,7 +9,7 @@
             [schema.core :as s])
   (:import (clojure.lang ExceptionInfo)
            (java.text Normalizer Normalizer$Form)
-           (java.time LocalDate)
+           (java.time Instant LocalDate)
            (java.util UUID)))
 
 (s/defschema herate-schema
@@ -63,6 +61,11 @@
   ^LocalDate []
   (LocalDate/now))
 
+(defn instant-now
+  "Abstraktio Instant/now:n ympäri, joka helpottaa testaamista."
+  ^Instant []
+  (Instant/now))
+
 (defn has-time-to-answer?
   "Tarkistaa, onko aikaa jäljellä ennen annettua päivämäärää."
   [loppupvm]
@@ -90,14 +93,6 @@
                 (log/warn "Ei hoksia " (:ehoks-id item))
                 (throw e)))))
         (throw e)))))
-
-(defn date-string-to-timestamp
-  "Muuttaa stringinä olevan päivämäärän timestampiksi (long)."
-  ([date-str fmt]
-   (c/to-long (f/parse (fmt f/formatters)
-                       date-str)))
-  ([date-str]
-   (date-string-to-timestamp date-str :date)))
 
 (defn get-koulutustoimija-oid
   "Hakee koulutustoimijan OID:n opiskeluoikeudesta, tai organisaatiopalvelusta
@@ -197,19 +192,16 @@
   [koulutustoimija timestamp]
   (let [item (ddb/get-item {:organisaatio-oid [:s koulutustoimija]}
                            (:orgwhitelist-table env))]
-    (if (or (.isBefore (LocalDate/of 2021 6 30)
-                       (LocalDate/ofEpochDay (/ timestamp 86400000)))
+    ; 1625086799 = 2021-06-30 12:59:59
+    (if (or (.isBefore (Instant/ofEpochSecond 1625086799) timestamp)
             (and (:kayttoonottopvm item)
-                 (<= (c/to-long (f/parse (:date f/formatters)
-                                         (:kayttoonottopvm item)))
-                     timestamp)
-                 (<= (c/to-long (f/parse (:date f/formatters)
-                                         (:kayttoonottopvm item)))
-                     (c/to-long (local-date-now)))))
+                 (.isBefore (Instant/parse (:kayttoonottopvm item)) timestamp)
+                 (.isBefore (Instant/parse (:kayttoonottopvm item))
+                            (instant-now))))
       true
       (log/info "Koulutustoimija" koulutustoimija
                 "ei ole mukana automaatiossa, tai herätepvm"
-                (str (LocalDate/ofEpochDay (/ timestamp 86400000)))
+                (first (str/split (str timestamp) #"T"))
                 "on ennen käyttöönotto päivämäärää"))))
 
 (defn check-duplicate-herate?

--- a/src/oph/heratepalvelu/external/koski.clj
+++ b/src/oph/heratepalvelu/external/koski.clj
@@ -35,8 +35,8 @@
   "Hakee opiskeluoikeudet, joihin on tehty päivityksiä datetime-str:n jälkeen."
   [start end page]
   (let [params {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
-                "opiskeluoikeusPäättynytAikaisintaan" start
-                "opiskeluoikeusPäättynytViimeistään"  end
+                "opiskeluoikeusPäättynytAikaisintaan" (str start)
+                "opiskeluoikeusPäättynytViimeistään"  (str end)
                 "pageSize"                            100
                 "pageNumber"                          page}
         resp (koski-get "/oppija/" {:query-params params

--- a/src/oph/heratepalvelu/external/koski.clj
+++ b/src/oph/heratepalvelu/external/koski.clj
@@ -31,15 +31,15 @@
                         (= 404 (:status (ex-data e))))
            (throw e)))))
 
-(defn get-updated-opiskeluoikeudet
+(defn get-completed-opiskeluoikeudet
   "Hakee opiskeluoikeudet, joihin on tehty päivityksiä datetime-str:n jälkeen."
-  [datetime-str page]
-  (let [resp (koski-get
-               "/oppija/"
-               {:query-params {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
-                               "muuttunutJälkeen"       datetime-str
-                               "pageSize"               100
-                               "pageNumber"             page}
-                :as           :json-strict})]
+  [start end page]
+  (let [params {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
+                "opiskeluoikeusPäättynytAikaisintaan" start
+                "opiskeluoikeusPäättynytViimeistään"  end
+                "pageSize"                            100
+                "pageNumber"                          page}
+        resp (koski-get "/oppija/" {:query-params params
+                                    :as :json-strict})]
     (sort-by :aikaleima
              (reduce #(into %1 (:opiskeluoikeudet %2)) [] (:body resp)))))

--- a/src/oph/heratepalvelu/external/koski.clj
+++ b/src/oph/heratepalvelu/external/koski.clj
@@ -1,8 +1,9 @@
 (ns oph.heratepalvelu.external.koski
   "Wrapperit Kosken REST-rajapinnan ympäri."
-  (:require [oph.heratepalvelu.external.http-client :as client]
+  (:require [clojure.string :as s]
+            [environ.core :refer [env]]
             [oph.heratepalvelu.external.aws-ssm :as ssm]
-            [environ.core :refer [env]])
+            [oph.heratepalvelu.external.http-client :as client])
   (:import (clojure.lang ExceptionInfo)))
 
 (def ^:private pwd
@@ -34,9 +35,10 @@
 (defn get-completed-opiskeluoikeudet
   "Hakee opiskeluoikeudet, joihin on tehty päivityksiä datetime-str:n jälkeen."
   [start end page]
-  (let [params {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
-                "opiskeluoikeusPäättynytAikaisintaan" (str start)
-                "opiskeluoikeusPäättynytViimeistään"  (str end)
+  (let [get-date #(first (s/split (str %) #"T"))
+        params {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
+                "opiskeluoikeusPäättynytAikaisintaan" (get-date start)
+                "opiskeluoikeusPäättynytViimeistään"  (get-date end)
                 "pageSize"                            100
                 "pageNumber"                          page}
         resp (koski-get "/oppija/" {:query-params params

--- a/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
@@ -224,13 +224,10 @@
       {:key "opiskeluoikeus-last-page"
        :value "0"})))
 
-(defn- mock-get-updated-opiskeluoikeudet [last-checked last-page]
-  (reset! test-handleUpdatedOpiskeluoikeus-results
-          (str @test-handleUpdatedOpiskeluoikeus-results
-               last-checked
-               " "
-               last-page
-               " "))
+(defn- mock-get-completed-opiskeluoikeudet [start end page]
+  (reset!
+    test-handleUpdatedOpiskeluoikeus-results
+    (str @test-handleUpdatedOpiskeluoikeus-results start " " end " " page " "))
   [{:oid "1.2.3"}])
 
 (defn- mock-get-koulutustoimija-oid [opiskeluoikeus]
@@ -312,7 +309,8 @@
 (deftest test-handleUpdatedOpiskeluoikeus
   (testing "Varmista, että -handleUpdatedOpiskeluoikeus tekee kutsuja oikein"
     (with-redefs
-      [environ.core/env {:metadata-table "metadata-table-name"}
+      [clj-time.coerce/from-long (fn [x] "2021-12-30T01:00:00.00Z")
+       environ.core/env {:metadata-table "metadata-table-name"}
        oph.heratepalvelu.amis.AMISCommon/save-herate mock-save-herate
        oph.heratepalvelu.amis.UpdatedOpiskeluoikeusHandler/check-tila
        mock-check-tila
@@ -333,12 +331,12 @@
        oph.heratepalvelu.db.dynamodb/get-item mock-get-item
        oph.heratepalvelu.external.ehoks/get-hoks-by-opiskeluoikeus
        mock-get-hoks-by-opiskeluoikeus
-       oph.heratepalvelu.external.koski/get-updated-opiskeluoikeudet
-       mock-get-updated-opiskeluoikeudet]
+       oph.heratepalvelu.external.koski/get-completed-opiskeluoikeudet
+       mock-get-completed-opiskeluoikeudet]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
-            expected (str "2021-12-14T10:30:00.000Z 0 {:oid \"1.2.3\"} "
-                          "{:oid \"1.2.3\"} 2021-10-10 "
+            expected (str "2021-12-14T10:30:00.000Z 2021-12-30T01:00:00.00Z "
+                          "0 {:oid \"1.2.3\"} {:oid \"1.2.3\"} 2021-10-10 "
                           "test-koulutustoimija-oid 1633824000000 "
                           "{:oid \"1.2.3\"} 2021-10-10 "
                           "get-hoks-by-opiskeluoikeus: 1.2.3 "

--- a/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
@@ -338,7 +338,7 @@
             context (tu/mock-handler-context)
             expected (str "2021-12-14T10:30:00.000Z 2021-12-30T01:00:00Z "
                           "0 {:oid \"1.2.3\"} {:oid \"1.2.3\"} 2021-10-10 "
-                          "test-koulutustoimija-oid 1633824000000 "
+                          "test-koulutustoimija-oid 2021-10-10T00:00:00Z "
                           "{:oid \"1.2.3\"} 2021-10-10 "
                           "get-hoks-by-opiskeluoikeus: 1.2.3 "
                           "get-kysely-type save-herate: "

--- a/test/oph/heratepalvelu/common_test.clj
+++ b/test/oph/heratepalvelu/common_test.clj
@@ -49,11 +49,6 @@
                 {:suoritukset [{:tyyppi {:koodiarvo "valma"}}
                                {:tyyppi {:koodiarvo "telma"}}]})))))
 
-(deftest test-date-string-to-timestamp
-  (testing "Transforming date-string to timestamp"
-    (is (= (date-string-to-timestamp "1970-01-01") 0))
-    (is (= (date-string-to-timestamp "2019-08-01") 1564617600000))))
-
 (deftest test-has-time-to-answer
   (let [date1 (t/today)
         date2 (t/plus (t/now) (t/days 1))

--- a/test/oph/heratepalvelu/common_test.clj
+++ b/test/oph/heratepalvelu/common_test.clj
@@ -1,9 +1,8 @@
 (ns oph.heratepalvelu.common-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [oph.heratepalvelu.common :refer :all]
-            [oph.heratepalvelu.test-util :refer :all]
-            [clj-time.core :as t]
-            [clojure.string :as str])
+            [oph.heratepalvelu.test-util :refer :all])
   (:import (java.time LocalDate)))
 
 (deftest test-get-koulutustoimija-oid
@@ -50,15 +49,9 @@
                                {:tyyppi {:koodiarvo "telma"}}]})))))
 
 (deftest test-has-time-to-answer
-  (let [date1 (t/today)
-        date2 (t/plus (t/now) (t/days 1))
-        date3 (t/minus  (t/now) (t/days 1))]
-    (is (true? (has-time-to-answer?
-                 (str date1))))
-    (is (true? (has-time-to-answer?
-                 (str date2))))
-    (is (false? (has-time-to-answer?
-                  (str date3))))))
+  (is (true? (has-time-to-answer? (str (LocalDate/now)))))
+  (is (true? (has-time-to-answer? (str (.plusDays (LocalDate/now) 1)))))
+  (is (false? (has-time-to-answer? (str (.minusDays (LocalDate/now) 1))))))
 
 (deftest test-create-nipputunniste
   (testing "Create normalized nipputunniste"

--- a/test/oph/heratepalvelu/external/koski_test.clj
+++ b/test/oph/heratepalvelu/external/koski_test.clj
@@ -29,23 +29,23 @@
                   mock-throws-other-error]
       (is (thrown? ExceptionInfo (koski/get-opiskeluoikeus-catch-404 "1.2"))))))
 
-(def test-get-updated-opiskeluoikeudet-saved-params (atom {}))
+(def test-get-completed-opiskeluoikeudet-saved-params (atom {}))
 
-(defn- mock-get-updated-opiskeluoikeudet-client-get [uri options]
-  (reset! test-get-updated-opiskeluoikeudet-saved-params {:uri uri
-                                                          :options options})
+(defn- mock-get-completed-opiskeluoikeudet-client-get [uri options]
+  (reset! test-get-completed-opiskeluoikeudet-saved-params {:uri uri
+                                                            :options options})
   {:body [{:opiskeluoikeudet [{:aikaleima "2021-01-01"}
                               {:aikaleima "2020-04-04"}]}
           {:opiskeluoikeudet [{:aikaleima "2020-11-11"}
                               {:aikaleima "2022-01-25"}
                               {:aikaleima "2021-05-05"}]}]})
 
-(deftest test-get-updated-opiskeluoikeudet
+(deftest test-get-completed-opiskeluoikeudet
   (testing "get-updated-opiskeluoikeudet tekee oikean kutsun ja käsittelyn"
     (with-redefs [environ.core/env {:koski-url "example.com/koski"
                                     :koski-user "user"}
                   oph.heratepalvelu.external.http-client/get
-                  mock-get-updated-opiskeluoikeudet-client-get
+                  mock-get-completed-opiskeluoikeudet-client-get
                   oph.heratepalvelu.external.koski/pwd (delay "secret")]
       (let [expected [{:aikaleima "2020-04-04"}
                       {:aikaleima "2020-11-11"}
@@ -56,11 +56,14 @@
                             :options
                             {:query-params
                              {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
-                              "muuttunutJälkeen" "2021-12-15"
+                              "opiskeluoikeusPäättynytAikaisintaan" "2021-12-15"
+                              "opiskeluoikeusPäättynytViimeistään" "2021-12-30"
                               "pageSize" 100
                               "pageNumber" 3}
                              :basic-auth ["user" "secret"]
                              :as :json-strict}}]
-        (is (= expected (koski/get-updated-opiskeluoikeudet "2021-12-15" 3)))
+        (is (= expected (koski/get-completed-opiskeluoikeudet "2021-12-15"
+                                                              "2021-12-30"
+                                                              3)))
         (is (= expected-saved
-               @test-get-updated-opiskeluoikeudet-saved-params))))))
+               @test-get-completed-opiskeluoikeudet-saved-params))))))

--- a/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
@@ -37,10 +37,8 @@
                 (str (:koski-url mock-env) "/oppija/")
                 {:query-params
                  {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
-                  "opiskeluoikeusPäättynytAikaisintaan"
-                  "2022-02-02T00:00:00.000Z"
-                  "opiskeluoikeusPäättynytViimeistään"
-                  "2022-02-04T00:05:00.000Z"
+                  "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02"
+                  "opiskeluoikeusPäättynytViimeistään" "2022-02-04"
                   "pageSize" 100
                   "pageNumber" 0}
                  :basic-auth [(:koski-user mock-env) "koski-pwd"]
@@ -74,10 +72,8 @@
                 (str (:koski-url mock-env) "/oppija/")
                 {:query-params
                  {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
-                  "opiskeluoikeusPäättynytAikaisintaan"
-                  "2022-02-02T00:00:00.000Z"
-                  "opiskeluoikeusPäättynytViimeistään"
-                  "2022-02-04T00:05:00.000Z"
+                  "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02"
+                  "opiskeluoikeusPäättynytViimeistään" "2022-02-04"
                   "pageSize" 100
                   "pageNumber" 1}
                  :basic-auth [(:koski-user mock-env) "koski-pwd"]
@@ -173,8 +169,8 @@
     :url (str (:koski-url mock-env) "/oppija/")
     :options {:query-params
               {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
-               "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02T00:00:00.000Z"
-               "opiskeluoikeusPäättynytViimeistään"  "2022-02-04T00:05:00.000Z"
+               "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02"
+               "opiskeluoikeusPäättynytViimeistään"  "2022-02-04"
                "pageSize"                            100
                "pageNumber"                          0}
               :basic-auth [(:koski-user mock-env) "koski-pwd"]
@@ -212,8 +208,8 @@
     :url (str (:koski-url mock-env) "/oppija/")
     :options {:query-params
               {"opiskeluoikeudenTyyppi"              "ammatillinenkoulutus"
-               "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02T00:00:00.000Z"
-               "opiskeluoikeusPäättynytViimeistään"  "2022-02-04T00:05:00.000Z"
+               "opiskeluoikeusPäättynytAikaisintaan" "2022-02-02"
+               "opiskeluoikeusPäättynytViimeistään"  "2022-02-04"
                "pageSize"                            100
                "pageNumber"                          1}
               :basic-auth [(:koski-user mock-env) "koski-pwd"]

--- a/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
@@ -1,13 +1,12 @@
 (ns oph.heratepalvelu.integration-tests.amis.UpdatedOpiskeluoikeusHandler-i-test
-  (:require [clj-time.coerce :as ctime]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [oph.heratepalvelu.amis.UpdatedOpiskeluoikeusHandler :as uoh]
             [oph.heratepalvelu.common :as c]
             [oph.heratepalvelu.integration-tests.mock-cas-client :as mcc]
             [oph.heratepalvelu.integration-tests.mock-db :as mdb]
             [oph.heratepalvelu.integration-tests.mock-http-client :as mhc]
             [oph.heratepalvelu.test-util :as tu])
-  (:import (java.time LocalDate)))
+  (:import (java.time Instant LocalDate)))
 
 (def mock-env {:orgwhitelist-table "orgwhitelist-table-name"
                :metadata-table "metadata-table-name"
@@ -134,7 +133,7 @@
   (mdb/clear-mock-db))
 
 (def expected-table-contents #{{:key [:s "opiskeluoikeus-last-checked"]
-                                :value [:s "2022-02-04T00:00:00.000Z"]}
+                                :value [:s "2022-02-04T00:00:00Z"]}
                                {:key [:s "opiskeluoikeus-last-page"]
                                 :value [:s "0"]}})
 
@@ -232,9 +231,9 @@
   (testing "UpdatedOpiskeluoikeusHandler integraatiotesti"
     (with-redefs
       [environ.core/env mock-env
-       oph.heratepalvelu.amis.UpdatedOpiskeluoikeusHandler/current-time-millis
-       (fn [] (ctime/from-long 1643933100000)) ; 2022-02-04 00:05:00
        oph.heratepalvelu.common/generate-uuid (fn [] "test-uuid")
+       oph.heratepalvelu.common/instant-now
+       (fn [] (Instant/ofEpochSecond 1643933100)) ; 2022-02-04 00:05:00
        oph.heratepalvelu.common/local-date-now
        (fn [] (LocalDate/of 2022 2 4))
        oph.heratepalvelu.db.dynamodb/get-item mdb/get-item

--- a/test/oph/heratepalvelu/test_util.clj
+++ b/test/oph/heratepalvelu/test_util.clj
@@ -1,11 +1,11 @@
 (ns oph.heratepalvelu.test-util
   (:require [cheshire.core :refer :all]
             [clojure.java.io :as io]
-            [clojure.string :as string]
-            [clj-time.core :as t])
+            [clojure.string :as string])
   (:import (com.amazonaws.services.lambda.runtime.events SQSEvent)
            (com.amazonaws.services.lambda.runtime.events SQSEvent$SQSMessage
                                                          ScheduledEvent)
+           (java.time LocalDate)
            (software.amazon.awssdk.awscore.exception AwsServiceException)
            (software.amazon.awssdk.services.dynamodb.model
              ConditionalCheckFailedException)))
@@ -47,11 +47,11 @@
     (= "1.2.246.562.10.346830761111"
        (last (:organisaatio-oid conds)))
     {:organisaatio-oid "1.2.246.562.10.346830761111"
-     :kayttoonottopvm (str (t/plus (t/today) (t/days 1)))}
+     :kayttoonottopvm (str (.plusDays (LocalDate/now) 1))}
     (= "1.2.246.562.10.346830761112"
        (last (:organisaatio-oid conds)))
     {:organisaatio-oid "1.2.246.562.10.346830761112"
-     :kayttoonottopvm  (str (t/today))}))
+     :kayttoonottopvm  (str (LocalDate/now))}))
 
 (def dummy-opiskeluoikeus-oid "1.2.246.562.24.10442483592")
 (def dummy-request-id "1d6c30bb-a2d9-5540-aa1a-65410fc2f8f5")

--- a/test/oph/heratepalvelu/tpk/tpkNiputusHandler_test.clj
+++ b/test/oph/heratepalvelu/tpk/tpkNiputusHandler_test.clj
@@ -1,6 +1,5 @@
 (ns oph.heratepalvelu.tpk.tpkNiputusHandler-test
-  (:require [clj-time.core :as t]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.tpk.tpkNiputusHandler :as tpk]
             [oph.heratepalvelu.test-util :as tu])
@@ -106,7 +105,7 @@
               :koulutustoimija-oid          "1.2.246.562.10.346830761110"
               :tiedonkeruu-alkupvm          "2021-07-01"
               :tiedonkeruu-loppupvm         "2021-12-31"
-              :niputuspvm                   (str (t/today))})))))
+              :niputuspvm                   (str (LocalDate/now))})))))
 
 (deftest test-get-existing-nippu
   (testing "Varmistaa, että get-existing-nippu kutsuu get-item oikein"


### PR DESCRIPTION
Hakee äskettäin päättyneet opiskeluoikeudet ja luo niille herätteet AMIS-tietokantaan.

Tämän muutoksen rinnalla clj-time -paketti on lopullisesti poistettu projektista ja korvattu java.time -paketin luokilla.