### PR TITLE
Käytä consistent readeja niputusHandlerissa

### DIFF
--- a/src/oph/heratepalvelu/db/dynamodb.clj
+++ b/src/oph/heratepalvelu/db/dynamodb.clj
@@ -175,6 +175,8 @@
                                            (.indexName (:index options))
                                            (:limit options)
                                            (.limit (int (:limit options)))
+                                           (:consistent-read options)
+                                           (.consistentRead true)
                                            (:filter-expression options)
                                            (.filterExpression
                                              (:filter-expression options))

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -221,7 +221,8 @@
   (ddb/query-items {:kasittelytila [:eq [:s (:ei-niputettu c/kasittelytilat)]]
                     :niputuspvm    [:le [:s (str (c/local-date-now))]]}
                    {:index "niputusIndex"
-                    :limit 10}
+                    :limit 10
+                    :consistent-read true}
                    (:nippu-table env)))
 
 (defn -handleNiputus


### PR DESCRIPTION
Uskon, että äskeiset niputusHandler-virheet johtuvat eventual consistency ongelmasta DynamoDB:ssä — eli joskus nippuun tehdyt muutokset (linkin tallennus) eivät ehtineet tallentua kantaan ennen kuin nippu haettiin uudestaan seuraavassa haussa.

ConsistentRead-parametri varmistaa, että kaikki writet heijastuvat niitä seuraavissa readeissa.