### PR TITLE
OY-3959: Poista työpaikkaohjaajan yhteystiedot

### DIFF
--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -260,6 +260,8 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       targets: [new targets.LambdaFunction(timedOperationsHandler)]
     });
 
+    jaksotunnusTable.grantReadWriteData(timedOperationsHandler);
+
     // jaksoHandler
 
     const jaksoHandler = new lambda.Function(this, "TEPJaksoHandler", {

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -243,6 +243,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       code: lambdaCode,
       environment: {
         ...this.envVars,
+        jaksotunnus_table: jaksotunnusTable.tableName,
         caller_id: `1.2.246.562.10.00000000001.${id}-timedOperationsHandler`,
       },
       memorySize: Token.asNumber(1024),

--- a/src/oph/heratepalvelu/external/ehoks.clj
+++ b/src/oph/heratepalvelu/external/ehoks.clj
@@ -38,6 +38,13 @@
                                "application/json")
                         options))))
 
+(defn- ehoks-delete
+  "Tekee DELETE-kyselyn ehoksiin."
+  ([uri-path] (ehoks-delete uri-path {}))
+  ([uri-path options]
+   (client/delete (str (:ehoks-url env) uri-path)
+                  (merge (ehoks-query-base-options) options))))
+
 (defn get-hoks-by-opiskeluoikeus
   "Hakee HOKSin opiskeluoikeuden OID:n perusteella."
   [oo-oid]
@@ -137,3 +144,9 @@
   "Lähettää tiedon henkilön tietojen muutoksesta eHOKS-palveluun."
   [oppija-oid]
   (ehoks-post (str "heratepalvelu/onrmodify") {:query-params {:oid oppija-oid}}))
+
+(defn delete-tyopaikkaohjaajan-yhteystiedot
+  "Poistaa työpaikkaohjaajan yhteystiedot yli kolme kuukautta sitten
+  päättyneistä työelämäjaksoista"
+  []
+  (ehoks-delete "heratepalvelu/tyopaikkaohjaajan-yhteystiedot" {}))

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -1,7 +1,9 @@
 (ns oph.heratepalvelu.tep.ehoksTimedOperationsHandler
   "Käsittelee ajastettuja operaatioita TEP-puolella."
   (:require [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
             [oph.heratepalvelu.common :as c]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.external.ehoks :as ehoks]))
 
 (gen-class
@@ -11,10 +13,25 @@
               com.amazonaws.services.lambda.runtime.Context] void]])
 
 (defn -handleTimedOperations
-  "Pyytää ehoksia lähettää käsittelemättömät jaksot SQS:iin."
+  "Pyytää ehoksia lähettää käsittelemättömät jaksot SQS:iin ja käynnistää
+   työpaikkaohjaajan yhteystietojen poiston."
   [_ _ _]
   (log/info "Käynnistetään jaksojen lähetys")
   (let [resp (ehoks/get-paattyneet-tyoelamajaksot "2021-07-01"
                                                   (str (c/local-date-now))
                                                   1500)]
-    (log/info "Lähetetty" (:data (:body resp)) "viestiä")))
+    (log/info "Lähetetty" (:data (:body resp)) "viestiä"))
+
+  (log/info "Käynnistetään työpaikkaohjaajan yhteystietojen poisto")
+  (let [hankkimistavat
+        (get-in (ehoks/delete-tyopaikkaohjaajan-yhteystiedot)
+                [:body :data :hankkimistapa-ids])]
+    (doseq [hankkimistapa_id hankkimistavat]
+      (ddb/update-item
+       {:hankkimistapa_id [:n hankkimistapa_id]}
+       {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
+        :expr-attr-names {"#eml" "ohjaaja_email"
+                          "#puh" "ohjaaja_puhelinnumero"}
+        :expr-attr-vals {":eml_value" [:s nil] ":puh_value" [:s nil]}}
+       (:jaksotunnus-table env)))
+    (log/info "Poistettu" (count hankkimistavat) "ohjaajan yhteystiedot")))

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -28,13 +28,13 @@
                 [:body :data :hankkimistapa-ids])]
     (doseq [hankkimistapa_id hankkimistavat]
       (log/info "Poistetaan ohjaajan yhteystiedot (hankkimistapa_id = "
-                (:tjk-id hankkimistapa_id)
+                hankkimistapa_id
                 ")")
       (ddb/update-item
        {:hankkimistapa_id [:n hankkimistapa_id]}
        {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
         :expr-attr-names {"#eml" "ohjaaja_email"
                           "#puh" "ohjaaja_puhelinnumero"}
-        :expr-attr-vals {":eml_value" [:s nil] ":puh_value" [:s nil]}}
+        :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
        (:jaksotunnus-table env)))
     (log/info "Poistettu" (count hankkimistavat) "ohjaajan yhteystiedot")))

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -27,6 +27,9 @@
         (get-in (ehoks/delete-tyopaikkaohjaajan-yhteystiedot)
                 [:body :data :hankkimistapa-ids])]
     (doseq [hankkimistapa_id hankkimistavat]
+      (log/info "Poistetaan ohjaajan yhteystiedot (hankkimistapa_id = "
+                (:tjk-id hankkimistapa_id)
+                ")")
       (ddb/update-item
        {:hankkimistapa_id [:n hankkimistapa_id]}
        {:update-expr "SET #eml = :eml_value, #puh = :puh_value"

--- a/test/oph/heratepalvelu/integration_tests/tep/ehoksTimedOperationsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/ehoksTimedOperationsHandler_i_test.clj
@@ -109,13 +109,13 @@
                     :message "Poistettu 3 ohjaajan yhteystiedot"})))
       (is (= (mdb/get-table-values (:jaksotunnus-table mock-env))
              #{{:hankkimistapa_id [:n 1]
-                :ohjaaja_email [:s nil]
-                :ohjaaja_puhelinnumero [:s nil]}
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}
                {:hankkimistapa_id [:n 2]
-                :ohjaaja_email [:s nil]
-                :ohjaaja_puhelinnumero [:s nil]}
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}
                {:hankkimistapa_id [:n 3]
-                :ohjaaja_email [:s nil]
-                :ohjaaja_puhelinnumero [:s nil]}}))
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}}))
 
       (teardown-test))))

--- a/test/oph/heratepalvelu/integration_tests/tep/ehoksTimedOperationsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/ehoksTimedOperationsHandler_i_test.clj
@@ -1,12 +1,25 @@
 (ns oph.heratepalvelu.integration-tests.tep.ehoksTimedOperationsHandler-i-test
   (:require [clojure.test :refer :all]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.integration-tests.mock-cas-client :as mcc]
             [oph.heratepalvelu.integration-tests.mock-http-client :as mhc]
             [oph.heratepalvelu.tep.ehoksTimedOperationsHandler :as etoh]
-            [oph.heratepalvelu.test-util :as tu])
+            [oph.heratepalvelu.test-util :as tu]
+            [oph.heratepalvelu.integration-tests.mock-db :as mdb])
   (:import (java.time LocalDate)))
 
-(def mock-env {:ehoks-url "https://oph-ehoks.com/"})
+(def mock-env {:ehoks-url "https://oph-ehoks.com/"
+               :jaksotunnus-table "jaksotunnus-table"})
+
+(def starting-table-contents [{:hankkimistapa_id [:n 1]
+                               :ohjaaja_email [:s "ohjaaja1@yritys.fi"]
+                               :ohjaaja_puhelinnumero [:s "0401111111"]}
+                              {:hankkimistapa_id [:n 2]
+                               :ohjaaja_email [:s "ohjaaja2@yritys.fi"]
+                               :ohjaaja_puhelinnumero [:s "0401111112"]}
+                              {:hankkimistapa_id [:n 3]
+                               :ohjaaja_email [:s "ohjaaja3@yritys.fi"]
+                               :ohjaaja_puhelinnumero [:s "0401111113"]}])
 
 (defn- setup-test []
   (mcc/clear-results)
@@ -16,17 +29,31 @@
                 (str (:ehoks-url mock-env) "heratepalvelu/tyoelamajaksot")
                 {:query-params {:start "2021-07-01"
                                 :end "2022-02-02"
-                                :limit 1000}
+                                :limit 1500}
                  :as :json
                  :headers
                  {:ticket
                   "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
-                {:body {:data 2}}))
+                {:body {:data 2}})
+  (mhc/bind-url :delete
+                (str (:ehoks-url mock-env)
+                     "heratepalvelu/tyopaikkaohjaajan-yhteystiedot")
+                {:as :json
+                 :headers
+                 {:ticket
+                  "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
+                {:body {:data {:hankkimistapa-ids [1 2 3]}}})
+  (mdb/clear-mock-db)
+  (mdb/create-table (:jaksotunnus-table mock-env)
+                    {:primary-key :hankkimistapa_id
+                     :sort-key :hankkimistapa_id})
+  (mdb/set-table-contents (:jaksotunnus-table mock-env) starting-table-contents))
 
 (defn- teardown-test []
   (mcc/clear-results)
   (mhc/clear-results)
-  (mhc/clear-url-bindings))
+  (mhc/clear-url-bindings)
+  (mdb/clear-mock-db))
 
 (def expected-http-results
   [{:method :get
@@ -34,10 +61,19 @@
     :options
     {:headers {:ticket
                "service-ticket/ehoks-virkailija-backend/cas-security-check"}
-     :query-params {:start "2021-07-01" :end "2022-02-02" :limit 1500}
+     :as :json
+     :query-params {:start "2021-07-01" :end "2022-02-02" :limit 1500}}}
+   {:method :delete
+    :url "https://oph-ehoks.com/heratepalvelu/tyopaikkaohjaajan-yhteystiedot"
+    :options
+    {:headers {:ticket
+               "service-ticket/ehoks-virkailija-backend/cas-security-check"}
      :as :json}}])
 
 (def expected-cas-client-results [{:type :get-service-ticket
+                                   :service "/ehoks-virkailija-backend"
+                                   :suffix "cas-security-check"}
+                                  {:type :get-service-ticket
                                    :service "/ehoks-virkailija-backend"
                                    :suffix "cas-security-check"}])
 
@@ -49,7 +85,9 @@
                   (fn [] (LocalDate/of 2022 2 2))
                   oph.heratepalvelu.external.cas-client/get-service-ticket
                   mcc/mock-get-service-ticket
-                  oph.heratepalvelu.external.http-client/get mhc/mock-get]
+                  oph.heratepalvelu.external.http-client/get mhc/mock-get
+                  oph.heratepalvelu.external.http-client/delete mhc/mock-delete
+                  ddb/update-item mdb/update-item]
       (setup-test)
       (etoh/-handleTimedOperations {}
                                    (tu/mock-handler-event :scheduledherate)
@@ -61,4 +99,23 @@
                     :message "Käynnistetään jaksojen lähetys"})))
       (is (true? (tu/logs-contain? {:level :info
                                     :message "Lähetetty 2 viestiä"})))
+
+      (is (true? (tu/logs-contain?
+                   {:level :info
+                    :message
+                    "Käynnistetään työpaikkaohjaajan yhteystietojen poisto"})))
+      (is (true? (tu/logs-contain?
+                   {:level :info
+                    :message "Poistettu 3 ohjaajan yhteystiedot"})))
+      (is (= (mdb/get-table-values (:jaksotunnus-table mock-env))
+             #{{:hankkimistapa_id [:n 1]
+                :ohjaaja_email [:s nil]
+                :ohjaaja_puhelinnumero [:s nil]}
+               {:hankkimistapa_id [:n 2]
+                :ohjaaja_email [:s nil]
+                :ohjaaja_puhelinnumero [:s nil]}
+               {:hankkimistapa_id [:n 3]
+                :ohjaaja_email [:s nil]
+                :ohjaaja_puhelinnumero [:s nil]}}))
+
       (teardown-test))))

--- a/test/oph/heratepalvelu/tep/ehoksTimedOperationsHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/ehoksTimedOperationsHandler_test.clj
@@ -1,24 +1,36 @@
 (ns oph.heratepalvelu.tep.ehoksTimedOperationsHandler-test
   (:require [clojure.test :refer :all]
             [oph.heratepalvelu.tep.ehoksTimedOperationsHandler :as etoh]
+            [oph.heratepalvelu.external.ehoks :as ehoks]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.test-util :as tu])
   (:import (java.time LocalDate)))
 
 (use-fixtures :each tu/clear-logs-before-test)
 
 (def results (atom {}))
+(def delete-endpoint-called (atom false))
+(def update-item-called (atom 0))
 
 (defn- mock-get-paattyneet-tyoelamajaksot [start end limit]
   (reset! results {:start start :end end})
   {:body {:data limit}})
 
+(defn- mock-delete-call []
+  (reset! delete-endpoint-called true)
+  {:body {:data {:hankkimistapa-ids [1 2 3]}}})
+
+(defn- mock-update-item [_ __ ___]
+  (swap! update-item-called inc))
+
 (deftest test-handleTimedOperations
-  (testing "Varmista, että -handleTimedOperations kutsuu ehoks-palvelun oikein"
-    (with-redefs [clojure.tools.logging/log* tu/mock-log*
-                  oph.heratepalvelu.common/local-date-now
-                  (fn [] (LocalDate/of 2021 10 10))
-                  oph.heratepalvelu.external.ehoks/get-paattyneet-tyoelamajaksot
-                  mock-get-paattyneet-tyoelamajaksot]
+  (testing "Varmista, että -handleTimedOperations kutsuu ehoks-palvelua oikein"
+    (with-redefs
+      [clojure.tools.logging/log* tu/mock-log*
+       oph.heratepalvelu.common/local-date-now (fn [] (LocalDate/of 2021 10 10))
+       ehoks/get-paattyneet-tyoelamajaksot mock-get-paattyneet-tyoelamajaksot
+       ehoks/delete-tyopaikkaohjaajan-yhteystiedot mock-delete-call
+       ddb/update-item mock-update-item]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
             expected {:start "2021-07-01" :end "2021-10-10"}]
@@ -29,4 +41,14 @@
                       :message "Käynnistetään jaksojen lähetys"})))
         (is (true? (tu/logs-contain?
                      {:level :info
-                      :message "Lähetetty 1500 viestiä"})))))))
+                      :message "Lähetetty 1500 viestiä"})))
+
+        (is (true?
+          (tu/logs-contain?
+            {:level :info
+             :message
+             "Käynnistetään työpaikkaohjaajan yhteystietojen poisto"})))
+        (is (true? @delete-endpoint-called))
+        (is (true? (tu/logs-contain?
+                     {:level :info
+                      :message "Poistettu 3 ohjaajan yhteystiedot"})))))))


### PR DESCRIPTION
Teknisesti tämä toimii niin, että kun timedOperationsHandler ajetaan ajastetusti (tunnin tai parin välein), niin se kutsuu ehoksia, joka poistaa yhteystiedot ensin ehoksin kannasta ja palauttaa sitten palautettujen rivien id:t, joiden perusteella timedOperationsHandler sitten poistaa yhteystiedot herätepalvelun kannasta.