### PR TITLE
OY-3960: Opiskelijan yhteystietojen poisto

### DIFF
--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -95,6 +95,15 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
       projectionType: dynamodb.ProjectionType.ALL
     });
 
+    AMISherateTable.addGlobalSecondaryIndex({
+      indexName: "ehoksIdIndex",
+      partitionKey: {
+        name: "ehoks-id",
+        type: dynamodb.AttributeType.NUMBER
+      },
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY
+    })
+
     const organisaatioWhitelistTable = new dynamodb.Table(
       this,
       "OrganisaatioWhitelistTable",

--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -539,6 +539,7 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
         code: lambdaCode,
         environment: {
           ...this.envVars,
+          herate_table: AMISherateTable.tableName,
           caller_id: `1.2.246.562.10.00000000001.${id}-AMISTimedOperationsHandler`,
         },
         memorySize: Token.asNumber(1024),

--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -549,6 +549,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
       }
     );
 
+    AMISherateTable.grantReadWriteData(AMISTimedOperationsHandler);
+
     new events.Rule(this, "AMISTimedOperationsScheduleRule", {
       schedule: events.Schedule.expression(
         `rate(${this.getParameterFromSsm("timedoperations-rate")})`

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -31,7 +31,7 @@
   (log/info "Käynnistetään opiskelijan yhteystietojen poisto")
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
                        [:body :data :hoks-ids])]
-    (log/info "Poistettuja hokseja" (count hoksit) "kpl")
+    (log/info "Käydään läpi" (count hoksit) "hoksin tiedot")
     (doseq [hoks hoksit]
       (let [resp (ddb/scan {:filter-expression   "#id = :id"
                             :expr-attr-names     {"#id" "ehoks-id"}

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -30,11 +30,12 @@
 
   (log/info "Käynnistetään opiskelijan yhteystietojen poisto")
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
-                       [:body :data :hoksit])]
+                       [:body :data :hoks-ids])]
+    (log/info "Poistettuja hokseja" (count hoksit) "kpl")
     (doseq [hoks hoksit]
       (let [resp (ddb/scan {:filter-expression   "#id = :id"
                             :expr-attr-names     {"#id" "ehoks-id"}
-                            :expr-attr-vals      {":id" [:n (:hoks-id hoks)]}}
+                            :expr-attr-vals      {":id" [:n hoks]}}
                            (:herate-table env))
             items (:items resp)]
         (doseq [item items]
@@ -52,7 +53,7 @@
                                "#puh" "puhelinnumero"}
              :expr-attr-vals  {":eml_value" [:s ""] ":puh_value" [:s ""]}}
             (:herate-table env)))))
-    (log/info "Poistettu" (count hoksit) "opiskelijan yhteystiedot")))
+    (log/info "Opiskelijan yhteystietojen poisto valmis")))
 
 (defn -handleMassHerateResend
   "Pyytää ehoksia lähettämäan viime 2 viikon herätteet uudestaan."

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -33,14 +33,14 @@
                        [:body :data :hoks-ids])]
     (doseq [hoks-id hoksit]
       (log/info "Poistetaan opiskelijan yhteystiedot (ehoks-id = "
-                (:tjk-id hoks-id)
+                hoks-id
                 ")")
       (ddb/update-item
        {:ehoks-id [:n hoks-id]}
        {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
         :expr-attr-names {"#eml" "sahkoposti"
                           "#puh" "puhelinnumero"}
-        :expr-attr-vals {":eml_value" [:s nil] ":puh_value" [:s nil]}}
+        :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
        (:herate-table env)))
     (log/info "Poistettu" (count hoksit) "opiskelijan yhteystiedot")))
 

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -32,6 +32,9 @@
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
                        [:body :data :hoks-ids])]
     (doseq [hoks-id hoksit]
+      (log/info "Poistetaan opiskelijan yhteystiedot (ehoks-id = "
+                (:tjk-id hoks-id)
+                ")")
       (ddb/update-item
        {:ehoks-id [:n hoks-id]}
        {:update-expr "SET #eml = :eml_value, #puh = :puh_value"

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -30,13 +30,15 @@
 
   (log/info "Käynnistetään opiskelijan yhteystietojen poisto")
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
-                       [:body :data :hoks-ids])]
-    (doseq [hoks-id hoksit]
-      (log/info "Poistetaan opiskelijan yhteystiedot (ehoks-id = "
-                hoks-id
-                ")")
+                       [:body :data :hoksit])]
+    (doseq [hoks hoksit]
+      (log/info (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = "
+                     (:koulutustoimija-oid hoks) "/" (:oppija-oid hoks)
+                     ")"))
       (ddb/update-item
-       {:ehoks-id [:n hoks-id]}
+       {:toimija_oppija [:s (str (:koulutustoimija-oid hoks)
+                                 "/"
+                                 (:oppija-oid hoks))]}
        {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
         :expr-attr-names {"#eml" "sahkoposti"
                           "#puh" "puhelinnumero"}

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -32,7 +32,8 @@
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
                        [:body :data :hoksit])]
     (doseq [hoks hoksit]
-      (let [resp (ddb/scan {:filter-expression   "ehoks-id = :id"
+      (let [resp (ddb/scan {:filter-expression   "#id = :id"
+                            :expr-attr-names     {"#id" "ehoks-id"}
                             :expr-attr-vals      {":id" [:n (:hoks-id hoks)]}}
                            (:herate-table env))
             items (:items resp)]

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -32,18 +32,19 @@
   (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
                        [:body :data :hoksit])]
     (doseq [hoks hoksit]
-      (log/info (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = "
-                     (:koulutustoimija-oid hoks) "/" (:oppija-oid hoks)
-                     ")"))
-      (ddb/update-item
-       {:toimija_oppija [:s (str (:koulutustoimija-oid hoks)
-                                 "/"
-                                 (:oppija-oid hoks))]}
-       {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
-        :expr-attr-names {"#eml" "sahkoposti"
-                          "#puh" "puhelinnumero"}
-        :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
-       (:herate-table env)))
+      (let [toimija-oppija (str (:koulutustoimija-oid hoks)
+                                "/"
+                                (:oppija-oid hoks))]
+        (log/info (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = "
+                       toimija-oppija
+                       ")"))
+        (ddb/update-item
+         {:toimija_oppija [:s toimija-oppija]}
+         {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
+          :expr-attr-names {"#eml" "sahkoposti"
+                            "#puh" "puhelinnumero"}
+          :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
+         (:herate-table env))))
     (log/info "Poistettu" (count hoksit) "opiskelijan yhteystiedot")))
 
 (defn -handleMassHerateResend

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -1,7 +1,9 @@
 (ns oph.heratepalvelu.amis.AMISehoksTimedOperationsHandler
   "Käsittelee ajastettuja operaatioita AMIS-puolella."
   (:require [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
             [oph.heratepalvelu.common :as c]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.external.ehoks :as ehoks]))
 
 (gen-class
@@ -17,13 +19,27 @@
               com.amazonaws.services.lambda.runtime.Context] void]])
 
 (defn -handleAMISTimedOperations
-  "Pyytää ehoksia lähettämään käsittelemättömät herätteet uudestaan."
+  "Pyytää ehoksia lähettämään käsittelemättömät herätteet uudestaan ja
+   käynnistää opiskelijan yhteystietojen poiston."
   [_ _ _]
   (log/info "Käynnistetään herätteiden lähetys")
   (let [resp (ehoks/get-retry-kyselylinkit "2021-07-01"
                                            (str (c/local-date-now))
                                            1000)]
-    (log/info "Lähetetty" (:data (:body resp)) "viestiä")))
+    (log/info "Lähetetty" (:data (:body resp)) "viestiä"))
+
+  (log/info "Käynnistetään opiskelijan yhteystietojen poisto")
+  (let [hoksit (get-in (ehoks/delete-opiskelijan-yhteystiedot)
+                       [:body :data :hoks-ids])]
+    (doseq [hoks-id hoksit]
+      (ddb/update-item
+       {:ehoks-id [:n hoks-id]}
+       {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
+        :expr-attr-names {"#eml" "sahkoposti"
+                          "#puh" "puhelinnumero"}
+        :expr-attr-vals {":eml_value" [:s nil] ":puh_value" [:s nil]}}
+       (:herate-table env)))
+    (log/info "Poistettu" (count hoksit) "opiskelijan yhteystiedot")))
 
 (defn -handleMassHerateResend
   "Pyytää ehoksia lähettämäan viime 2 viikon herätteet uudestaan."

--- a/src/oph/heratepalvelu/external/ehoks.clj
+++ b/src/oph/heratepalvelu/external/ehoks.clj
@@ -150,3 +150,9 @@
   päättyneistä työelämäjaksoista"
   []
   (ehoks-delete "heratepalvelu/tyopaikkaohjaajan-yhteystiedot" {}))
+
+(defn delete-opiskelijan-yhteystiedot
+  "Poistaa opiskelijan yhteystiedot yli kolme kuukautta sitten
+  päättyneistä hokseista"
+  []
+  (ehoks-delete "heratepalvelu/opiskelijan-yhteystiedot" {}))

--- a/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
@@ -18,7 +18,15 @@
 
 (defn- mock-delete-call []
   (reset! delete-endpoint-called true)
-  {:body {:data {:hoks-ids [1 2 3]}}})
+  {:body {:data {:hoksit [{:ehoks-id 1
+                           :koulutustoimija-oid "1"
+                           :oppija-oid "1"}
+                          {:ehoks-id 2
+                           :koulutustoimija-oid "2"
+                           :oppija-oid "2"}
+                          {:ehoks-id 3
+                           :koulutustoimija-oid "3"
+                           :oppija-oid "3"}]}}})
 
 (defn- mock-update-item [_ __ ___]
   (swap! update-item-called inc))

--- a/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
@@ -19,15 +19,7 @@
 
 (defn- mock-delete-call []
   (reset! delete-endpoint-called true)
-  {:body {:data {:hoksit [{:ehoks-id 1
-                           :koulutustoimija-oid "1"
-                           :oppija-oid "1"}
-                          {:ehoks-id 2
-                           :koulutustoimija-oid "2"
-                           :oppija-oid "2"}
-                          {:ehoks-id 3
-                           :koulutustoimija-oid "3"
-                           :oppija-oid "3"}]}}})
+  {:body {:data {:hoks-ids [1 2 3]}}})
 
 (defn- mock-scan [_ __]
   (swap! scan-called inc)
@@ -60,16 +52,17 @@
                       :message "Lähetetty 1000 viestiä"})))
 
         (is (true?
-             (tu/logs-contain?
-              {:level :info
-               :message
-               "Käynnistetään opiskelijan yhteystietojen poisto"})))
+              (tu/logs-contain?
+                {:level :info
+                 :message
+                 "Käynnistetään opiskelijan yhteystietojen poisto"})))
         (is (true? @delete-endpoint-called))
         (is (= @scan-called 3))
         (is (= @update-item-called 3))
-        (is (true? (tu/logs-contain?
-                    {:level :info
-                     :message "Poistettu 3 opiskelijan yhteystiedot"})))))))
+        (is (true?
+              (tu/logs-contain?
+                {:level :info
+                 :message "Opiskelijan yhteystietojen poisto valmis"})))))))
 
 (def mass-resend-results (atom []))
 

--- a/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler_test.clj
@@ -1,16 +1,27 @@
 (ns oph.heratepalvelu.amis.AMISehoksTimedOperationsHandler-test
   (:require [clojure.test :refer :all]
             [oph.heratepalvelu.amis.AMISehoksTimedOperationsHandler :as etoh]
+            [oph.heratepalvelu.external.ehoks :as ehoks]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.test-util :as tu])
   (:import (java.time LocalDate)))
 
 (use-fixtures :each tu/clear-logs-before-test)
 
 (def results (atom {}))
+(def delete-endpoint-called (atom false))
+(def update-item-called (atom 0))
 
 (defn- mock-get-retry-kyselylinkit [start end limit]
   (reset! results {:start start :end end})
   {:body {:data limit}})
+
+(defn- mock-delete-call []
+  (reset! delete-endpoint-called true)
+  {:body {:data {:hoks-ids [1 2 3]}}})
+
+(defn- mock-update-item [_ __ ___]
+  (swap! update-item-called inc))
 
 (deftest test-handleAMISTimedOperations
   (testing "Varmista, että -handleAMISTimedOperations toimii oikein"
@@ -18,7 +29,9 @@
                   oph.heratepalvelu.common/local-date-now
                   (fn [] (LocalDate/of 2022 2 2))
                   oph.heratepalvelu.external.ehoks/get-retry-kyselylinkit
-                  mock-get-retry-kyselylinkit]
+                  mock-get-retry-kyselylinkit
+                  ehoks/delete-opiskelijan-yhteystiedot mock-delete-call
+                  ddb/update-item mock-update-item]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
             expected {:start "2021-07-01" :end "2022-02-02"}]
@@ -29,7 +42,17 @@
                       :message "Käynnistetään herätteiden lähetys"})))
         (is (true? (tu/logs-contain?
                      {:level :info
-                      :message "Lähetetty 1000 viestiä"})))))))
+                      :message "Lähetetty 1000 viestiä"})))
+
+        (is (true?
+             (tu/logs-contain?
+              {:level :info
+               :message
+               "Käynnistetään opiskelijan yhteystietojen poisto"})))
+        (is (true? @delete-endpoint-called))
+        (is (true? (tu/logs-contain?
+                    {:level :info
+                     :message "Poistettu 3 opiskelijan yhteystiedot"})))))))
 
 (def mass-resend-results (atom []))
 

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
@@ -11,13 +11,16 @@
 (def mock-env {:ehoks-url "https://oph-ehoks.com/"
                :herate-table "herate-table"})
 
-(def starting-table-contents [{:ehoks-id [:n 1]
+(def starting-table-contents [{:toimija_oppija [:s "1/1"]
+                               :ehoks-id [:n 1]
                                :sahkoposti [:s "oppilas1@gmail.com"]
                                :puhelinnumero [:s "0402222222"]}
-                              {:ehoks-id [:n 2]
+                              {:toimija_oppija [:s "2/2"]
+                               :ehoks-id [:n 2]
                                :sahkoposti [:s "oppilas2@gmail.com"]
                                :puhelinnumero [:s "0402222223"]}
-                              {:ehoks-id [:n 3]
+                              {:toimija_oppija [:s "3/3"]
+                               :ehoks-id [:n 3]
                                :sahkoposti [:s "oppilas3@gmail.com"]
                                :puhelinnumero [:s "0402222224"]}])
 
@@ -42,11 +45,18 @@
                  :headers
                  {:ticket
                   "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
-                {:body {:data {:hoks-ids [1 2 3]}}})
+                {:body {:data {:hoksit [{:ehoks-id 1
+                                         :koulutustoimija-oid "1"
+                                         :oppija-oid "1"}
+                                        {:ehoks-id 2
+                                         :koulutustoimija-oid "2"
+                                         :oppija-oid "2"}
+                                        {:ehoks-id 3
+                                         :koulutustoimija-oid "3"
+                                         :oppija-oid "3"}]}}})
   (mdb/clear-mock-db)
   (mdb/create-table (:herate-table mock-env)
-                    {:primary-key :ehoks-id
-                     :sort-key :ehoks-id})
+                    {:primary-key :toimija_oppija})
   (mdb/set-table-contents (:herate-table mock-env) starting-table-contents))
 
 (defn- teardown-test []
@@ -110,13 +120,16 @@
                   {:level :info
                    :message "Poistettu 3 opiskelijan yhteystiedot"})))
       (is (= (mdb/get-table-values (:herate-table mock-env))
-             #{{:ehoks-id [:n 1]
+             #{{:toimija_oppija [:s "1/1"]
+                :ehoks-id [:n 1]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}
-               {:ehoks-id [:n 2]
+               {:toimija_oppija [:s "2/2"]
+                :ehoks-id [:n 2]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}
-               {:ehoks-id [:n 3]
+               {:toimija_oppija [:s "3/3"]
+                :ehoks-id [:n 3]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}}))
       (teardown-test))))

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
@@ -1,12 +1,25 @@
 (ns oph.heratepalvelu.integration-tests.amis.AMISehoksTimedOpsHandler-i-test
   (:require [clojure.test :refer :all]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.amis.AMISehoksTimedOperationsHandler :as toh]
             [oph.heratepalvelu.integration-tests.mock-cas-client :as mcc]
             [oph.heratepalvelu.integration-tests.mock-http-client :as mhc]
-            [oph.heratepalvelu.test-util :as tu])
+            [oph.heratepalvelu.test-util :as tu]
+            [oph.heratepalvelu.integration-tests.mock-db :as mdb])
   (:import (java.time LocalDate)))
 
-(def mock-env {:ehoks-url "https://oph-ehoks.com/"})
+(def mock-env {:ehoks-url "https://oph-ehoks.com/"
+               :herate-table "herate-table"})
+
+(def starting-table-contents [{:ehoks-id [:n 1]
+                               :sahkoposti [:s "oppilas1@gmail.com"]
+                               :puhelinnumero [:s "0402222222"]}
+                              {:ehoks-id [:n 2]
+                               :sahkoposti [:s "oppilas2@gmail.com"]
+                               :puhelinnumero [:s "0402222223"]}
+                              {:ehoks-id [:n 3]
+                               :sahkoposti [:s "oppilas3@gmail.com"]
+                               :puhelinnumero [:s "0402222224"]}])
 
 (defn- setup-test []
   (mcc/clear-results)
@@ -21,12 +34,26 @@
      :as :json
      :headers {:ticket
                "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
-    {:body {:data 2}}))
+    {:body {:data 2}})
+  (mhc/bind-url :delete
+                (str (:ehoks-url mock-env)
+                     "heratepalvelu/opiskelijan-yhteystiedot")
+                {:as :json
+                 :headers
+                 {:ticket
+                  "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
+                {:body {:data {:hoks-ids [1 2 3]}}})
+  (mdb/clear-mock-db)
+  (mdb/create-table (:herate-table mock-env)
+                    {:primary-key :ehoks-id
+                     :sort-key :ehoks-id})
+  (mdb/set-table-contents (:herate-table mock-env) starting-table-contents))
 
 (defn- teardown-test []
   (mcc/clear-results)
   (mhc/clear-results)
-  (mhc/clear-url-bindings))
+  (mhc/clear-url-bindings)
+  (mdb/clear-mock-db))
 
 (def expected-http-results
   [{:method :get
@@ -37,9 +64,18 @@
      :query-params {:start "2021-07-01"
                     :end "2022-02-02"
                     :limit 1000}
+     :as :json}}
+   {:method :delete
+    :url "https://oph-ehoks.com/heratepalvelu/opiskelijan-yhteystiedot"
+    :options
+    {:headers {:ticket
+               "service-ticket/ehoks-virkailija-backend/cas-security-check"}
      :as :json}}])
 
 (def expected-cas-client-results [{:type :get-service-ticket
+                                   :service "/ehoks-virkailija-backend"
+                                   :suffix "cas-security-check"}
+                                  {:type :get-service-ticket
                                    :service "/ehoks-virkailija-backend"
                                    :suffix "cas-security-check"}])
 
@@ -51,7 +87,9 @@
                   (fn [] (LocalDate/of 2022 2 2))
                   oph.heratepalvelu.external.cas-client/get-service-ticket
                   mcc/mock-get-service-ticket
-                  oph.heratepalvelu.external.http-client/get mhc/mock-get]
+                  oph.heratepalvelu.external.http-client/get mhc/mock-get
+                  oph.heratepalvelu.external.http-client/delete mhc/mock-delete
+                  ddb/update-item mdb/update-item]
       (setup-test)
       (toh/-handleAMISTimedOperations {}
                                       (tu/mock-handler-event :scheduledherate)
@@ -63,6 +101,24 @@
                     :message "Käynnistetään herätteiden lähetys"})))
       (is (true? (tu/logs-contain? {:level :info
                                     :message "Lähetetty 2 viestiä"})))
+
+      (is (true? (tu/logs-contain?
+                  {:level :info
+                   :message
+                   "Käynnistetään opiskelijan yhteystietojen poisto"})))
+      (is (true? (tu/logs-contain?
+                  {:level :info
+                   :message "Poistettu 3 opiskelijan yhteystiedot"})))
+      (is (= (mdb/get-table-values (:herate-table mock-env))
+             #{{:ehoks-id [:n 1]
+                :sahkoposti [:s nil]
+                :puhelinnumero [:s nil]}
+               {:ehoks-id [:n 2]
+                :sahkoposti [:s nil]
+                :puhelinnumero [:s nil]}
+               {:ehoks-id [:n 3]
+                :sahkoposti [:s nil]
+                :puhelinnumero [:s nil]}}))
       (teardown-test))))
 
 ;; -handleMassHerateResend testi

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
@@ -48,15 +48,7 @@
                  :headers
                  {:ticket
                   "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
-                {:body {:data {:hoksit [{:hoks-id 1
-                                         :koulutustoimija-oid "1"
-                                         :oppija-oid "1"}
-                                        {:hoks-id 2
-                                         :koulutustoimija-oid "2"
-                                         :oppija-oid "2"}
-                                        {:hoks-id 3
-                                         :koulutustoimija-oid "3"
-                                         :oppija-oid "3"}]}}})
+                {:body {:data {:hoks-ids [1 2 3]}}})
   (mdb/clear-mock-db)
   (mdb/create-table (:herate-table mock-env)
                     {:primary-key :toimija_oppija
@@ -121,9 +113,27 @@
                   {:level :info
                    :message
                    "Käynnistetään opiskelijan yhteystietojen poisto"})))
+      (is (true?
+            (tu/logs-contain?
+              {:level :info
+               :message
+               (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = 1/1,"
+                    " tyyppi_kausi = aloittaneet/2022-2023)")})))
+      (is (true?
+            (tu/logs-contain?
+              {:level :info
+               :message
+               (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = 2/2,"
+                    " tyyppi_kausi = aloittaneet/2022-2023)")})))
+      (is (true?
+            (tu/logs-contain?
+              {:level :info
+               :message
+               (str "Poistetaan opiskelijan yhteystiedot (toimija_oppija = 3/3,"
+                    " tyyppi_kausi = aloittaneet/2022-2023)")})))
       (is (true? (tu/logs-contain?
                   {:level :info
-                   :message "Poistettu 3 opiskelijan yhteystiedot"})))
+                   :message "Opiskelijan yhteystietojen poisto valmis"})))
       (is (= (mdb/get-table-values (:herate-table mock-env))
              #{{:toimija_oppija [:s "1/1"]
                 :tyyppi_kausi [:s "aloittaneet/2022-2023"]

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
@@ -111,14 +111,14 @@
                    :message "Poistettu 3 opiskelijan yhteystiedot"})))
       (is (= (mdb/get-table-values (:herate-table mock-env))
              #{{:ehoks-id [:n 1]
-                :sahkoposti [:s nil]
-                :puhelinnumero [:s nil]}
+                :sahkoposti [:s ""]
+                :puhelinnumero [:s ""]}
                {:ehoks-id [:n 2]
-                :sahkoposti [:s nil]
-                :puhelinnumero [:s nil]}
+                :sahkoposti [:s ""]
+                :puhelinnumero [:s ""]}
                {:ehoks-id [:n 3]
-                :sahkoposti [:s nil]
-                :puhelinnumero [:s nil]}}))
+                :sahkoposti [:s ""]
+                :puhelinnumero [:s ""]}}))
       (teardown-test))))
 
 ;; -handleMassHerateResend testi

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISehoksTimedOpsHandler_i_test.clj
@@ -12,14 +12,17 @@
                :herate-table "herate-table"})
 
 (def starting-table-contents [{:toimija_oppija [:s "1/1"]
+                               :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                                :ehoks-id [:n 1]
                                :sahkoposti [:s "oppilas1@gmail.com"]
                                :puhelinnumero [:s "0402222222"]}
                               {:toimija_oppija [:s "2/2"]
+                               :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                                :ehoks-id [:n 2]
                                :sahkoposti [:s "oppilas2@gmail.com"]
                                :puhelinnumero [:s "0402222223"]}
                               {:toimija_oppija [:s "3/3"]
+                               :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                                :ehoks-id [:n 3]
                                :sahkoposti [:s "oppilas3@gmail.com"]
                                :puhelinnumero [:s "0402222224"]}])
@@ -45,18 +48,19 @@
                  :headers
                  {:ticket
                   "service-ticket/ehoks-virkailija-backend/cas-security-check"}}
-                {:body {:data {:hoksit [{:ehoks-id 1
+                {:body {:data {:hoksit [{:hoks-id 1
                                          :koulutustoimija-oid "1"
                                          :oppija-oid "1"}
-                                        {:ehoks-id 2
+                                        {:hoks-id 2
                                          :koulutustoimija-oid "2"
                                          :oppija-oid "2"}
-                                        {:ehoks-id 3
+                                        {:hoks-id 3
                                          :koulutustoimija-oid "3"
                                          :oppija-oid "3"}]}}})
   (mdb/clear-mock-db)
   (mdb/create-table (:herate-table mock-env)
-                    {:primary-key :toimija_oppija})
+                    {:primary-key :toimija_oppija
+                     :sort-key    :tyyppi_kausi})
   (mdb/set-table-contents (:herate-table mock-env) starting-table-contents))
 
 (defn- teardown-test []
@@ -99,6 +103,7 @@
                   mcc/mock-get-service-ticket
                   oph.heratepalvelu.external.http-client/get mhc/mock-get
                   oph.heratepalvelu.external.http-client/delete mhc/mock-delete
+                  ddb/scan mdb/scan
                   ddb/update-item mdb/update-item]
       (setup-test)
       (toh/-handleAMISTimedOperations {}
@@ -121,14 +126,17 @@
                    :message "Poistettu 3 opiskelijan yhteystiedot"})))
       (is (= (mdb/get-table-values (:herate-table mock-env))
              #{{:toimija_oppija [:s "1/1"]
+                :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                 :ehoks-id [:n 1]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}
                {:toimija_oppija [:s "2/2"]
+                :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                 :ehoks-id [:n 2]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}
                {:toimija_oppija [:s "3/3"]
+                :tyyppi_kausi [:s "aloittaneet/2022-2023"]
                 :ehoks-id [:n 3]
                 :sahkoposti [:s ""]
                 :puhelinnumero [:s ""]}}))


### PR DESCRIPTION
Toimii vastaavalla tavalla kuin työpaikkaohjaajan yhteystietojen poisto, eli: Teknisesti tämä toimii niin, että kun amisTimedOperationsHandler ajetaan ajastetusti (tunnin tai parin välein), niin se kutsuu ehoksia, joka poistaa yhteystiedot ensin ehoksin kannasta ja palauttaa sitten palautettujen rivien id:t, joiden perusteella amisTimedOperationsHandler sitten poistaa yhteystiedot herätepalvelun kannasta.