### PR TITLE
Secure queues with server side encryption

### DIFF
--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -128,7 +128,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
 
     const herateDeadLetterQueue = new sqs.Queue(this, "HerateDeadLetterQueue", {
       retentionPeriod: Duration.days(14),
-      visibilityTimeout: (Duration.seconds(60))
+      visibilityTimeout: Duration.seconds(60),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ehoksHerateQueue = new sqs.Queue(this, "HerateQueue", {
@@ -138,12 +139,14 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
         maxReceiveCount: 5
       },
       visibilityTimeout: Duration.seconds(60),
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ONRhenkilomodifyDLQ = new sqs.Queue(this, "ONRhenkilomodifyDLQ", {
       retentionPeriod: Duration.days(14),
-      visibilityTimeout: (Duration.seconds(60))
+      visibilityTimeout: Duration.seconds(60),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ONRhenkilomodifyQueue = new sqs.Queue(this, "ONRhenkilomodifyQueue", {
@@ -153,7 +156,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
         maxReceiveCount: 5
       },
       visibilityTimeout: Duration.seconds(60),
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ONRhenkilomodifyTopic = sns.Topic.fromTopicArn(this, "ONRhenkilomodifyTopic",
@@ -162,7 +166,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
     ONRhenkilomodifyTopic.addSubscription(new snsSubs.SqsSubscription(ONRhenkilomodifyQueue));
 
     const ehoksAmisResendDLQueue = new sqs.Queue(this, "AmisResendDLQueue", {
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ehoksAmisResendQueue = new sqs.Queue(this, "AmisResendQueue", {
@@ -172,7 +177,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
         maxReceiveCount: 5
       },
       visibilityTimeout: Duration.seconds(60),
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const deleteTunnusDLQueue = new sqs.Queue(this, "AmisDeleteTunnusDLQueue", {
@@ -186,7 +192,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
         maxReceiveCount: 5
       },
       visibilityTimeout: Duration.seconds(60),
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const ehoksHerateAsset = new s3assets.Asset(

--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -1,16 +1,16 @@
 import { App, Duration, Token, StackProps } from 'aws-cdk-lib';
-import dynamodb = require("aws-cdk-lib/aws-dynamodb");
-import events = require("aws-cdk-lib/aws-events");
-import targets = require("aws-cdk-lib/aws-events-targets");
-import lambda = require("aws-cdk-lib/aws-lambda");
-import s3assets = require("aws-cdk-lib/aws-s3-assets");
-import sqs = require("aws-cdk-lib/aws-sqs");
-import sns = require("aws-cdk-lib/aws-sns");
-import snsSubs = require("aws-cdk-lib/aws-sns-subscriptions")
-import iam = require("aws-cdk-lib/aws-iam");
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as  lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
+import * as sqs from  'aws-cdk-lib/aws-sqs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as snsSubs from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { CfnEventSourceMapping } from "aws-cdk-lib/aws-lambda";
-import {HeratepalveluStack} from "./heratepalvelu";
+import { HeratepalveluStack } from "./heratepalvelu";
 
 
 

--- a/cdk/lib/heratepalvelu.ts
+++ b/cdk/lib/heratepalvelu.ts
@@ -1,5 +1,5 @@
 import { Stack, App, StackProps, Tags } from 'aws-cdk-lib';
-import ssm = require("aws-cdk-lib/aws-ssm");
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 export type EnvVars = {
   virkailija_url: string

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -205,7 +205,8 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
 
     const herateDeadLetterQueue = new sqs.Queue(this, "HerateDLQ", {
       retentionPeriod: Duration.days(14),
-      visibilityTimeout: (Duration.seconds(60))
+      visibilityTimeout: Duration.seconds(60),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     const herateQueue = new sqs.Queue(this, "HerateQueue", {
@@ -215,7 +216,8 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
         maxReceiveCount: 5
       },
       visibilityTimeout: Duration.seconds(60),
-      retentionPeriod: Duration.days(14)
+      retentionPeriod: Duration.days(14),
+      encryption: sqs.QueueEncryption.SQS_MANAGED
     });
 
     // S3

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -1,11 +1,11 @@
 import { App, Duration, Token, StackProps } from 'aws-cdk-lib';
-import dynamodb = require("aws-cdk-lib/aws-dynamodb");
-import events = require("aws-cdk-lib/aws-events");
-import targets = require("aws-cdk-lib/aws-events-targets");
-import lambda = require("aws-cdk-lib/aws-lambda");
-import s3assets = require("aws-cdk-lib/aws-s3-assets");
-import sqs = require("aws-cdk-lib/aws-sqs");
-import iam = require("aws-cdk-lib/aws-iam");
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { HeratepalveluStack } from "./heratepalvelu";
 import { CfnEventSourceMapping } from "aws-cdk-lib/aws-lambda";

--- a/cdk/lib/teprah.ts
+++ b/cdk/lib/teprah.ts
@@ -22,7 +22,8 @@ export class HeratepalveluTEPRAHOITUSStack extends HeratepalveluStack {
 
         const tepRahoitusDLQ = new sqs.Queue(this, "RahoitusLaskentaDLQ", {
             retentionPeriod: Duration.days(14),
-            visibilityTimeout: (Duration.seconds(60))
+            visibilityTimeout: Duration.seconds(60),
+            encryption: sqs.QueueEncryption.SQS_MANAGED
         });
 
         const tepRahoitusQueue = new sqs.Queue(this, "RahoitusLaskentaQueue", {
@@ -32,7 +33,8 @@ export class HeratepalveluTEPRAHOITUSStack extends HeratepalveluStack {
                 maxReceiveCount: 5
             },
             visibilityTimeout: Duration.seconds(90),
-            retentionPeriod: Duration.days(14)
+            retentionPeriod: Duration.days(14),
+            encryption: sqs.QueueEncryption.SQS_MANAGED
         });
 
 

--- a/cdk/lib/teprah.ts
+++ b/cdk/lib/teprah.ts
@@ -1,9 +1,9 @@
 import { App, Duration, Token, StackProps } from 'aws-cdk-lib';
-import dynamodb = require("aws-cdk-lib/aws-dynamodb");
-import lambda = require("aws-cdk-lib/aws-lambda");
-import s3assets = require("aws-cdk-lib/aws-s3-assets");
-import sqs = require("aws-cdk-lib/aws-sqs");
-import iam = require("aws-cdk-lib/aws-iam");
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { HeratepalveluStack } from "./heratepalvelu";
 

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -1,8 +1,8 @@
 import { App, Duration, Token, StackProps } from 'aws-cdk-lib';
-import dynamodb = require("aws-cdk-lib/aws-dynamodb");
-import lambda = require("aws-cdk-lib/aws-lambda");
-import s3assets = require("aws-cdk-lib/aws-s3-assets");
-import iam = require("aws-cdk-lib/aws-iam");
+import * as  dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3assets from 'aws-cdk-lib/aws-s3-assets';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { HeratepalveluStack } from "./heratepalvelu";
 
 export class HeratepalveluTPKStack extends HeratepalveluStack {


### PR DESCRIPTION
This needs to be tested in test environments, adding server-side encryption disables "anonymous" usage. I hope we don't have anonymous usage. SSL-enforcement could also be enabled but didn't want to have two changes in one branch.

- fix some imports with cdk style
- remove extra parentheses from Duration
- add server-side encryption for all queues