### PR TITLE
Lambda meneillään olevalla rahoituskaudella päättyneiden työpaikkajaksojen kestojen uudelleenlaskentaan

### DIFF
--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -510,6 +510,28 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
     });
 
     jaksotunnusTable.grantReadWriteData(dbChangerTep);
+    
+    const kestojenUudelleenlaskentaHandler = new lambda.Function(
+      this,
+      "kestojenUudelleenlaskentaHandler",
+      {
+        runtime: lambda.Runtime.JAVA_8_CORRETTO,
+        code: lambdaCode,
+        environment: {
+          ...this.envVars,
+          jaksotunnus_table: jaksotunnusTable.tableName,
+          nippu_table: nippuTable.tableName,
+          caller_id: `1.2.246.562.10.00000000001.${id}-kestojenUudelleenlaskentaHandler`,
+        },
+        memorySize: Token.asNumber(1024),
+        reservedConcurrentExecutions: 1,
+        timeout: Duration.seconds(900),
+        handler: "oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler::handleKestojenUudelleenlaskenta",
+        tracing: lambda.Tracing.ACTIVE
+    });
+
+    jaksotunnusTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
+    nippuTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
 
     // Arkistointifunktiot
     /*
@@ -564,6 +586,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       SmsMuistutusHandler,
       EmailMuistutusHandler,
       dbChangerTep,
+      kestojenUudelleenlaskentaHandler
       // archiveJaksoTable,
       // archiveNippuTable,
     ].forEach(

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -1,0 +1,65 @@
+(ns oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler
+  "TODO"
+  (:require [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
+            [oph.heratepalvelu.tep.tepCommon :as tc]
+            [oph.heratepalvelu.tep.niputusHandler :as nh]
+            [oph.heratepalvelu.log.caller-log :refer [log-caller-details-scheduled]]))
+
+(def rahoituskauden-alkupvm "2022-07-01")
+
+(defn scan-for-unhandled-nippus!
+  [exclusive-start-key]
+  (let [resp (ddb/scan
+               {:filter-expression "niputuspvm >= :alkupvm AND attribute_not_exists(#suoritettu)"
+                :exclusive-start-key exclusive-start-key
+                :expr-attr-names {"#suoritettu" "kestojen-uudelleenlaskenta-suoritettu"}
+                :expr-attr-vals {":alkupvm" [:s rahoituskauden-alkupvm]}}
+                (:nippu-table env))]
+    (log/info "Haettiin onnistuneesti " (count (:items resp)) " nippua")
+    resp))
+
+(defn query-jaksot-with-kesto!
+  "Hakee tietokannasta ne jaksot, jotka kuuluvat parametrina annettuun nippuun.
+  Suodattaan jaksoja edelleen siten, että jäljelle jääviltä jaksoilta löytyy
+  vanhastaan laskettu kesto, mutta ei uudella tavalla laskettua kestoa."
+  [nippu]
+  (ddb/query-items
+    {:ohjaaja_ytunnus_kj_tutkinto
+     [:eq [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]]
+     :niputuspvm [:eq [:s (:niputuspvm nippu)]]}
+    {:index "niputusIndex"
+     :filter-expression "attribute_exists(kesto) AND attribute_not_exists(#vanha)"}
+     :expr-attr-names {"#vanha" "kesto-vanha"}
+    (:jaksotunnus-table env)))
+
+(defn calculate-kestot!
+  [jaksot]
+  (apply
+    merge
+    (map (fn [oppijan-jaksot]
+           (let [concurrent-jaksot (nh/get-concurrent-jaksot-from-ehoks!
+                                    oppijan-jaksot)
+                 opiskeluoikeudet  (nh/get-and-memoize-opiskeluoikeudet!
+                                    concurrent-jaksot)]
+             (nh/calculate-kestot concurrent-jaksot opiskeluoikeudet)))
+          ; Ryhmitellään jaksot oppija-oid:n perusteella:
+         (vals (group-by :oppija_oid jaksot)))))
+
+(defn -handleKestojenUudelleenlaskenta
+  [_ event ^com.amazonaws.services.lambda.runtime.Context context]
+  (log-caller-details-scheduled "handleKestojenUudelleenlaskenta" event context)
+    (loop [niput (scan-for-unhandled-nippus! nil)]
+      (doseq [nippu (:items niput)]
+        (let [jaksot (query-jaksot-with-kesto! nippu)
+              kestot (calculate-kestot! jaksot)]
+          (doseq [jakso jaksot]
+            (tc/update-jakso jakso
+                             {:kesto [:n (get kestot
+                                              (:hankkimistapa_id jakso))]
+                              :kesto-vanha [:n (:kesto jakso)]})))
+        (tc/update-nippu nippu {:kestojen-uudelleenlaskenta-suoritettu [:bool true]}))
+      (when (and (< 30000 (.getRemainingTimeInMillis context))
+                 (:last-evaluated-key niput))
+        (recur (scan-for-unhandled-nippus! (:last-evaluated-key niput))))))

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -7,6 +7,12 @@
             [oph.heratepalvelu.tep.niputusHandler :as nh]
             [oph.heratepalvelu.log.caller-log :refer [log-caller-details-scheduled]]))
 
+(gen-class :name "oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler"
+           :methods
+           [[^:static handleKestojenUudelleenlaskenta
+             [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+              com.amazonaws.services.lambda.runtime.Context] void]])
+
 (def rahoituskauden-alkupvm "2022-07-01")
 
 (defn scan-for-unhandled-nippus!

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -60,6 +60,7 @@
       (doseq [nippu (:items niput)]
         (let [jaksot (query-jaksot-with-kesto! nippu)
               kestot (calculate-kestot! jaksot)]
+          (log/info "Jaksot: " jaksot ", Kestot: " kestot)
           (doseq [jakso jaksot]
             (tc/update-jakso jakso
                              {:kesto [:n (get kestot

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -64,7 +64,8 @@
           (doseq [jakso jaksot]
             (tc/update-jakso jakso
                              {:kesto [:n (get kestot
-                                              (:hankkimistapa_id jakso))]
+                                              (:hankkimistapa_id jakso)
+                                              0)]
                               :kesto-vanha [:n (:kesto jakso)]})))
         (tc/update-nippu nippu {:kestojen-uudelleenlaskenta-suoritettu [:bool true]}))
       (when (and (< 30000 (.getRemainingTimeInMillis context))

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -36,8 +36,8 @@
      [:eq [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]]
      :niputuspvm [:eq [:s (:niputuspvm nippu)]]}
     {:index "niputusIndex"
-     :filter-expression "attribute_exists(kesto) AND attribute_not_exists(#vanha)"}
-     :expr-attr-names {"#vanha" "kesto-vanha"}
+     :filter-expression "attribute_exists(kesto) AND attribute_not_exists(#vanha)"
+     :expr-attr-names {"#vanha" "kesto-vanha"}}
     (:jaksotunnus-table env)))
 
 (defn calculate-kestot!


### PR DESCRIPTION
Tämä vaatii toimiakseen alle https://github.com/Opetushallitus/heratepalvelu/pull/213.

Idea on, että lambdaa operoidaan samaan tyyliin kuin tpkNiputusHandleria tai tpkArvoCallHandleria, eli AWS:n Consolesta ajellaan kertaluontoisesti. Kts. referenssiksi [dokumentaatio edellä mainituista](https://github.com/Opetushallitus/heratepalvelu/blob/master/doc/tpk.md).

Lambda hakee siis skannaamalla joukon nippuja, jonka jaksoille kestojen uudelleenlaskentaa ei ole suoritettu. Hakukriteerit ovat tosiaan seuraavat
- kuuluu nykyiseen rahoituskauteen (`niputuspvm >= "2022-07-01"`) **ja**
- uudelleenlaskentaa ei ole tehty nipun jaksoille (ts. nipun tiedoista ei löydy kenttää `kestojen-uudelleenlaskenta-suoritettu`)

Kun on löydetty joukko nippuja, nipuista valitaan **vain jaksot joille on jo laskettu kesto**. Näille uusi kesto lasketaan aikalailla samaan tapaan kuin niputusHandlerin kestonlaskennassa on tehty (kts. https://github.com/Opetushallitus/heratepalvelu/pull/213). Poikkeuksena, että vanhalla menetelmällä laskettua kestoa ei lasketa toistamiseen (vrt. `calculate-kestot!` tämän PR:n tiedostossa vs. vastaavanniminen funktio em. PR:n `niputusHandler.clj`:ssa). Tässä toteutuksessa vanhastaan laskettu kesto siirretään kenttään `kesto-vanha`.

Lambda tosiaan hakee niin paljon nippuja kun se ehtii 15 minuutin sisällä prosessoida (loopissa jäljellä olevaa aikaa tarkistellaan lambdan contextista). Käsitellyt niput merkataan flagilla `kestojen-uudelleenlaskenta-suoritettu`, jolloin samoja nippuja ei tule käsittelyyn lambdan seuraavalla triggeröintikerralla.

Onko mietteitä toteutustavasta? Entäs, onko tarpeen tehdä yksikkötestejä, vai riittääkö katselmointi + testaaminen QA:lla? Tämän lambdan käyttö jää kuitenkin varmaan yhteen kertaan.