### PR TITLE
Replace unidiomatic instances of (reduce) with more specific library calls

### DIFF
--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -34,13 +34,10 @@
   "Palauttaa ensimmäisen hyväksyttävän suorituksen vahvistuspäivämäärän, jos
   sellainen on olemassa."
   [opiskeluoikeus]
-  (if-let [vahvistus-pvm
-           (reduce
-             (fn [_ suoritus]
-               (when (check-suoritus-type? suoritus)
-                 (reduced (get-in suoritus [:vahvistus :päivä]))))
-             nil (:suoritukset opiskeluoikeus))]
-    vahvistus-pvm
+  (or
+    (some #(and (check-suoritus-type? %)
+                (get-in % [:vahvistus :päivä]))
+          (:suoritukset opiskeluoikeus))
     (log/info "Opiskeluoikeudessa" (:oid opiskeluoikeus)
               "ei vahvistus päivämäärää")))
 

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -75,18 +75,6 @@
       (= tyyppi "ammatillinentutkintoosittainen")
       "tutkinnon_osia_suorittaneet")))
 
-(defn get-tila
-  "Hakee opiskeluoikeuden tilan."
-  [opiskeluoikeus vahvistus-pvm]
-  (let [tilat (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
-        voimassa (reduce
-                   (fn [res next]
-                     (if (>= (compare vahvistus-pvm (:alku next)) 0)
-                       next
-                       (reduced res)))
-                   (sort-by :alku tilat))]
-    (:koodiarvo (:tila voimassa))))
-
 (defn check-tila
   "Varmistaa, että opiskeluoikeuden tila on 'valmistunut' tai 'läsnä'."
   [opiskeluoikeus vahvistus-pvm]

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -184,11 +184,7 @@
 (defn get-suoritus
   "Hakee tutkinnon tai tutkinnon osan suorituksen opiskeluoikeudesta."
   [opiskeluoikeus]
-  (reduce
-    (fn [_ suoritus]
-      (when (check-suoritus-type? suoritus)
-        (reduced suoritus)))
-    nil (:suoritukset opiskeluoikeus)))
+  (first (filter check-suoritus-type? (:suoritukset opiskeluoikeus))))
 
 (defn has-nayttotutkintoonvalmistavakoulutus?
   "Tarkistaa, onko opiskeluoikeudessa näyttötutkintoon valmistavan koulutuksen
@@ -328,10 +324,11 @@
   "Luo options-objekti update-item -kutsulle."
   [updates]
   {:update-expr (str "SET " (str/join ", " (map make-set-pair (keys updates))))
-   :expr-attr-names (reduce #(assoc %1 (str "#" (normalize-string %2)) %2)
-                            {}
-                            (map name (keys updates)))
+   :expr-attr-names
+   (let [names (map name (keys updates))]
+     (zipmap (map #(str "#" (normalize-string %)) names) names))
    :expr-attr-vals
+   ; FIXME: map-keys
    (reduce-kv #(assoc %1 (str ":" (normalize-string (name %2))) %3)
               {}
               updates)})

--- a/src/oph/heratepalvelu/external/koski.clj
+++ b/src/oph/heratepalvelu/external/koski.clj
@@ -34,12 +34,12 @@
 (defn get-updated-opiskeluoikeudet
   "Hakee opiskeluoikeudet, joihin on tehty päivityksiä datetime-str:n jälkeen."
   [datetime-str page]
-  (let [resp (koski-get
-               "/oppija/"
-               {:query-params {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
-                               "muuttunutJälkeen"       datetime-str
-                               "pageSize"               100
-                               "pageNumber"             page}
-                :as           :json-strict})]
-    (sort-by :aikaleima
-             (reduce #(into %1 (:opiskeluoikeudet %2)) [] (:body resp)))))
+  (->> {:query-params {"opiskeluoikeudenTyyppi" "ammatillinenkoulutus"
+                       "muuttunutJälkeen"       datetime-str
+                       "pageSize"               100
+                       "pageNumber"             page}
+        :as           :json-strict}
+       (koski-get "/oppija/")
+       :body
+       (mapcat :opiskeluoikeudet)
+       (sort-by :aikaleima)))

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -33,11 +33,7 @@
   (let [ohjaaja-email (tc/reduce-common-value jaksot :ohjaaja_email)]
     (if (some? ohjaaja-email)
       ohjaaja-email
-      (let [osoitteet (reduce #(if (some? (:ohjaaja_email %2))
-                                 (conj %1 (:ohjaaja_email %2))
-                                 %1)
-                              #{}
-                              jaksot)]
+      (let [osoitteet (into #{} (keep :ohjaaja_email jaksot))]
         (log/warn "Ei yksiselitteistä ohjaajan sähköpostia "
                   (:ohjaaja_ytunnus_kj_tutkinto nippu) ","
                   (:niputuspvm nippu) "," osoitteet)

--- a/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
@@ -87,27 +87,6 @@
       (throw (ex-info (str "Tunnus " tunnus " on jo käytössä.")
                       {:items items})))))
 
-(defn check-opiskeluoikeus-tila
-  "Palauttaa true, jos opiskeluoikeus ei ole terminaalitilassa (eronnut,
-  katsotaan eronneeksi, mitätöity, peruutettu, tai väliaikaisesti keskeytynyt)."
-  [opiskeluoikeus loppupvm]
-  (let [tilat (:opiskeluoikeusjaksot (:tila opiskeluoikeus))
-        voimassa (reduce
-                   (fn [res next]
-                     (if (c/is-before (LocalDate/parse (:alku next))
-                                      (LocalDate/parse loppupvm))
-                       next
-                       (reduced res)))
-                   (sort-by :alku tilat))
-        tila (:koodiarvo (:tila voimassa))]
-    (if (or (= tila "eronnut")
-            (= tila "katsotaaneronneeksi")
-            (= tila "mitatoity")
-            (= tila "peruutettu")
-            (= tila "valiaikaisestikeskeytynyt"))
-      (log/warn "Opiskeluoikeus" (:oid opiskeluoikeus) "terminaalitilassa" tila)
-      true)))
-
 (defn sort-process-keskeytymisajanjaksot
   "Järjestää TEP-jakso keskeytymisajanjaksot, parsii niiden alku- ja
   loppupäivämäärät LocalDateiksi, ja palauttaa tuloslistan."
@@ -270,8 +249,8 @@
             (let [koulutustoimija (c/get-koulutustoimija-oid opiskeluoikeus)]
               (if (some? (tep-herate-checker herate))
                 (log/error {:herate herate :msg (tep-herate-checker herate)})
-                (when (and (check-opiskeluoikeus-tila opiskeluoikeus
-                                                      (:loppupvm herate))
+                (when (and (c/check-opiskeluoikeus-tila opiskeluoikeus
+                                                        (:loppupvm herate))
                            (check-not-fully-keskeytynyt herate)
                            (c/check-opiskeluoikeus-suoritus-types?
                              opiskeluoikeus)

--- a/src/oph/heratepalvelu/tep/tepCommon.clj
+++ b/src/oph/heratepalvelu/tep/tepCommon.clj
@@ -39,11 +39,8 @@
   "Jos kaikissa annetuissa objekteissa (items) on kentässä f sama arvo tai nil,
   palauttaa yhteisen arvon. Muuten palauttaa nil."
   [items f]
-  (reduce #(if (some? %1)
-             (if (and (some? (f %2)) (not= %1 (f %2))) (reduced nil) %1)
-             (f %2))
-          nil
-          items))
+  (let [values (set (keep f items))]
+    (if (= 1 (count values)) (first values))))
 
 (defn update-nippu
   "Wrapper update-itemin ympäri, joka yksinkertaistaa tietokantapäivitykset."

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -62,11 +62,7 @@
           (if (some? number)
             {:sms_kasittelytila [:s (:phone-invalid c/kasittelytilat)]
              :lahetettynumeroon [:s number]}
-            (let [numerot (reduce #(if (some? (:ohjaaja_puhelinnumero %2))
-                                     (conj %1 (:ohjaaja_puhelinnumero %2))
-                                     %1)
-                                  #{}
-                                  jaksot)]
+            (let [numerot (set (keep :ohjaaja_puhelinnumero jaksot))]
               (log/warn "Ei yksiselitteistä ohjaajan puhelinnumeroa,"
                         (count numerot)
                         "numeroa löydetty")

--- a/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
@@ -80,6 +80,7 @@
   [nippu]
   (try
     (ddb/put-item
+      ; FIXME: map-values
       (reduce #(assoc %1 (first %2) [:s (second %2)]) {} (seq nippu))
       {}
       (:tpk-nippu-table env))

--- a/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler_test.clj
@@ -67,45 +67,6 @@
                  :suoritukset [{:suorituskieli {:koodiarvo "FI"}
                                 :tyyppi {:koodiarvo "valma"}}]})))))
 
-(deftest test-get-tila
-  (testing "Get correct tila given opiskeluoikeus and vahvistus-pvm"
-    (is (= (get-tila
-             {:oid "1.2.246.562.15.82039738925"
-              :koulutustoimija {:oid "1.2.246.562.10.35751498086"}
-              :suoritukset [{:suorituskieli {:koodiarvo "FI"}
-                             :tyyppi
-                             {:koodiarvo "nayttotutkintoonvalmistavakoulutus"}
-                             :vahvistus {:päivä "2019-07-24"}}
-                            {:suorituskieli {:koodiarvo "FI"}
-                             :tyyppi
-                             {:koodiarvo "ammatillinentutkintoosittainen"}
-                             :vahvistus {:päivä "2019-07-23"}}]
-              :tila {:opiskeluoikeusjaksot [{:alku "2019-07-24"
-                                             :tila {:koodiarvo "lasna"}}
-                                            {:alku "2019-07-23"
-                                             :tila
-                                             {:koodiarvo "valmistunut"}}]}}
-             "2019-07-23")
-           "valmistunut"))
-    (is (= (get-tila
-             {:oid "1.2.246.562.15.82039738925"
-              :koulutustoimija {:oid "1.2.246.562.10.35751498086"}
-              :suoritukset [{:suorituskieli {:koodiarvo "FI"}
-                             :tyyppi
-                             {:koodiarvo "nayttotutkintoonvalmistavakoulutus"}
-                             :vahvistus {:päivä "2019-07-24"}}
-                            {:suorituskieli {:koodiarvo "FI"}
-                             :tyyppi
-                             {:koodiarvo "ammatillinentutkintoosittainen"}
-                             :vahvistus {:päivä "2019-07-23"}}]
-              :tila {:opiskeluoikeusjaksot [{:alku "2019-07-24"
-                                             :tila {:koodiarvo "lasna"}}
-                                            {:alku "2019-07-23"
-                                             :tila
-                                             {:koodiarvo "valmistunut"}}]}}
-             "2019-07-24")
-           "lasna"))))
-
 (deftest test-check-tila
   (testing "Check for acceptable tila given opiskeluoikeus and vahvistus-pvm"
     (is (check-tila

--- a/test/oph/heratepalvelu/integration_tests/mock_db.clj
+++ b/test/oph/heratepalvelu/integration_tests/mock_db.clj
@@ -50,7 +50,7 @@
             (assoc
               @mock-db-tables
               table-name
-              (reduce #(assoc %1 (get-item-key key-fields %2) %2) {} items)))))
+              (zipmap (map (partial get-item-key key-fields) items) items)))))
 
 (defn get-whole-table [table-name] (get @mock-db-tables table-name))
 

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -35,57 +35,6 @@
       (is (some? (jh/tep-herate-checker bad1)))
       (is (some? (jh/tep-herate-checker bad2))))))
 
-(deftest check-opiskeluoikeus-tila-test
-  (testing "Opiskeluoikeuden tilan tarkastus. Keskeytetty opiskeluoikeus estää
-           jakson käsittelyn. Jakson päättymispäivänä keskeytetty opiskeluoikeus
-           ei estä jakson käsittelyä."
-    (let [loppupvm "2021-09-07"
-          opiskeluoikeus-lasna {:tila
-                                {:opiskeluoikeusjaksot
-                                 [{:alku "2021-06-20"
-                                   :tila {:koodiarvo "loma"}}
-                                  {:alku "2021-05-01"
-                                   :tila {:koodiarvo "lasna"}}
-                                  {:alku "2021-06-25"
-                                   :tila {:koodiarvo "lasna"}}]}}
-          opiskeluoikeus-eronnut-samana-paivana {:tila
-                                                 {:opiskeluoikeusjaksot
-                                                  [{:alku "2021-06-20"
-                                                    :tila {:koodiarvo "loma"}}
-                                                   {:alku "2021-05-01"
-                                                    :tila {:koodiarvo "lasna"}}
-                                                   {:alku "2021-09-07"
-                                                    :tila
-                                                    {:koodiarvo "eronnut"}}]}}
-          opiskeluoikeus-eronnut-tulevaisuudessa {:tila
-                                                  {:opiskeluoikeusjaksot
-                                                   [{:alku "2021-06-20"
-                                                     :tila {:koodiarvo "loma"}}
-                                                    {:alku "2021-05-01"
-                                                     :tila {:koodiarvo "lasna"}}
-                                                    {:alku "2021-09-08"
-                                                     :tila
-                                                     {:koodiarvo "eronnut"}}]}}
-          opiskeluoikeus-eronnut-paivaa-aiemmin {:tila
-                                                 {:opiskeluoikeusjaksot
-                                                  [{:alku "2021-06-20"
-                                                    :tila {:koodiarvo "loma"}}
-                                                   {:alku "2021-05-01"
-                                                    :tila {:koodiarvo "lasna"}}
-                                                   {:alku "2021-09-06"
-                                                    :tila
-                                                    {:koodiarvo "eronnut"}}]}}]
-      (is (= true (jh/check-opiskeluoikeus-tila opiskeluoikeus-lasna loppupvm)))
-      (is (= true (jh/check-opiskeluoikeus-tila
-                    opiskeluoikeus-eronnut-samana-paivana
-                    loppupvm)))
-      (is (= true (jh/check-opiskeluoikeus-tila
-                    opiskeluoikeus-eronnut-tulevaisuudessa
-                    loppupvm)))
-      (is (nil? (jh/check-opiskeluoikeus-tila
-                  opiskeluoikeus-eronnut-paivaa-aiemmin
-                  loppupvm))))))
-
 (deftest check-sort-process-keskeytymisajanjaksot-test
   (testing "sort-process-keskeytymisajanjaksot test"
     (let [herate1 {:keskeytymisajanjaksot [{:alku  "2021-08-08"
@@ -558,14 +507,14 @@
                   mock-check-sisaltyy-opiskeluoikeuteen?
                   oph.heratepalvelu.common/get-koulutustoimija-oid
                   mock-get-koulutustoimija-oid
+                  oph.heratepalvelu.common/check-opiskeluoikeus-tila
+                  mock-check-opiskeluoikeus-tila
                   oph.heratepalvelu.external.ehoks/patch-oht-tep-kasitelty
                   mock-patch-oht-tep-kasitelty
                   oph.heratepalvelu.external.koski/get-opiskeluoikeus-catch-404
                   mock-get-opiskeluoikeus-catch-404
                   oph.heratepalvelu.tep.jaksoHandler/check-not-fully-keskeytynyt
                   mock-check-not-fully-keskeytynyt
-                  oph.heratepalvelu.tep.jaksoHandler/check-opiskeluoikeus-tila
-                  mock-check-opiskeluoikeus-tila
                   oph.heratepalvelu.tep.jaksoHandler/save-jaksotunnus
                   mock-save-jaksotunnus
                   oph.heratepalvelu.tep.jaksoHandler/tep-herate-checker

--- a/test/oph/heratepalvelu/tep/niputusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/niputusHandler_test.clj
@@ -147,6 +147,7 @@
 (def test-compute-kestot-new-results (atom []))
 
 (defn- do-rounding [values]
+  ; FIXME: map-values
   (reduce-kv #(assoc %1 %2 (/ (Math/round (* %3 1000.0)) 1000.0)) {} values))
 
 (defn- do-rounding-new [value]

--- a/test/oph/heratepalvelu/tpk/tpkNiputusHandler_test.clj
+++ b/test/oph/heratepalvelu/tpk/tpkNiputusHandler_test.clj
@@ -263,6 +263,7 @@
     :oppisopimuksen_perusta [:s "02"]}])
 
 (defn- get-specific-niputtamaton [index]
+  ; FIXME: map-values
   (reduce #(assoc %1 (first %2) (second (second %2)))
           {}
           (seq (get mock-niputtamattomat-list index))))


### PR DESCRIPTION
(Valmiiksi pahoittelut siitä että tää on niin turha PR :))

Huomasin, että herätepalvelun koodissa on aika paljon käytetty `(reduce)`-funktiota asioihin, joihin on paljon idiomaattisempia keinoja.  Tein tällaisen ehdotuksen, miltä niiden kutsujen ehkä pitäisi näyttää.  Hyöty on lähinnä  se, että koodista on helpompi nähdä, mitä se yrittää tehdä.

Voidaan käyttää tai olla käyttämättä näitä muutoksia.  Harmillisesti aina, kun tekee tällaisia, on jonkinlainen asioiden rikkoutumisen riski jos esim. testit eivät ota huomioon jotain nyansseja `nil` vs. `false` tai muuta vastaavaa.