### PR TITLE
Ei koskaan tehdä silmukassa samaa DDB-kyselyä uudestaan

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISDeleteTunnusHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISDeleteTunnusHandler.clj
@@ -52,4 +52,6 @@
             (delete-one-item
               (ac/get-herate-by-kyselylinkki! (:kyselylinkki herate)))))
         (catch JsonParseException e
-          (log/error e "Virhe viestin lukemisessa: " msg))))))
+          (log/error e "Virhe viestin lukemisessa: " msg))
+        (catch Exception e
+          (log/error e "herätteessä" msg))))))

--- a/src/oph/heratepalvelu/amis/AMISEmailResendHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISEmailResendHandler.clj
@@ -50,14 +50,10 @@
             (when (empty? (:sahkoposti herate))
               (log/warn "Ei sähköpostia, käytetään dynamoon tallennettua"
                         sahkoposti))
-            (try
-              (ac/update-herate
-                db-herate
-                {:lahetystila [:s (:ei-lahetetty c/kasittelytilat)]
-                 :sahkoposti  [:s sahkoposti]})
-              (catch AwsServiceException e
-                (log/error e "Virhe tilan päivityksessä herätteelle" db-herate)
-                (throw e)))))))
+            (ac/update-herate
+              db-herate
+              {:lahetystila [:s (:ei-lahetetty c/kasittelytilat)]
+               :sahkoposti  [:s sahkoposti]})))))
 
 (defn -handleEmailResend
   "Merkistee sähköpostin lähetettäväksi uudestaan, jos osoite löytyy
@@ -69,4 +65,6 @@
       (try
         (handle-single-herate! (parse-string (.getBody msg) true))
         (catch JsonParseException e
-          (log/error e "Virhe viestin lukemisessa:" msg))))))
+          (log/error e "Virhe viestin lukemisessa:" msg))
+        (catch Exception e
+          (log/error e "herätteellä" msg))))))

--- a/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
@@ -90,19 +90,13 @@
                                                         (- (* 5 (+ n 1)) 1)))]
                                    [:s (str (.minusDays (c/local-date-now)
                                                         (* 5 n)))]]]}
-                   {:index "muistutusIndex"
-                    :limit 50}))
+                   {:index "muistutusIndex"}))
 
 (defn -handleSendAMISMuistutus
   "Käsittelee AMISin muistutusviestien lähetystä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendAMISMuistutus" event context)
-  (loop [muistutettavat1 (query-muistutukset 1)
-         muistutettavat2 (query-muistutukset 2)]
+  (let [muistutettavat1 (query-muistutukset 1)
+        muistutettavat2 (query-muistutukset 2)]
     (sendAMISMuistutus muistutettavat1 1)
-    (sendAMISMuistutus muistutettavat2 2)
-    (when (and
-            (or (seq muistutettavat1) (seq muistutettavat2))
-            (< 60000 (.getRemainingTimeInMillis context)))
-      (recur (query-muistutukset 1)
-             (query-muistutukset 2)))))
+    (sendAMISMuistutus muistutettavat2 2)))

--- a/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
@@ -74,12 +74,8 @@
           (do
             (log/warn "Kyselylinkkiä ei löytynyt!  Merkitään loppuneeksi.")
             (update-when-not-sent herate n {}))
-          (do
-            (log/error e "virhe muistutuksen käsittelyssä, tiedot:" (ex-data e))
-            (throw e))))
-      (catch Exception e
-        (log/error e "virhe muistutuksen käsittelyssä")
-        (throw e)))))
+          (log/error e "tiedot:" (ex-data e))))
+      (catch Exception e (log/error e "herätteellä" herate)))))
 
 (defn query-muistutukset
   "Hakee tietokannasta herätteet, joilla on lähetettäviä muistutusviestejä."

--- a/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
@@ -56,8 +56,8 @@
   "Lähettää muistutusviestin ja tallentaa sen tilan tietokantaan, jos kyselyyn
   ei ole vastattu ja vastausaika ei ole umpeutunut."
   [timeout? muistutettavat n]
-  (log/info (str "Käsitellään " (count muistutettavat)
-                 " lähetettävää " n ". muistutusta."))
+  (log/info "Aiotaan käsitellä" (count muistutettavat) "lähetettävää"
+            (str n ".") "muistutusta.")
   (c/doseq-with-timeout
     timeout?
     [herate muistutettavat]

--- a/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISMuistutusHandler.clj
@@ -96,7 +96,6 @@
   "Käsittelee AMISin muistutusviestien lähetystä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendAMISMuistutus" event context)
-  (let [muistutettavat1 (query-muistutukset 1)
-        muistutettavat2 (query-muistutukset 2)]
-    (sendAMISMuistutus muistutettavat1 1)
-    (sendAMISMuistutus muistutettavat2 2)))
+  (doseq [kerta [1 2]]
+    (sendAMISMuistutus
+      (filter (c/time-left? context 60000) (query-muistutukset kerta)) kerta)))

--- a/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
@@ -84,10 +84,10 @@
   käsittelee viestien lähetystä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (cl/log-caller-details-scheduled "AMISSMSHandler" event context)
-  (let [lahetettavat (query-lahetettavat)]
-    (log/info "Käsitellään" (count lahetettavat) "lähetettävää SMS-viestiä.")
+  (let [lahetettavat (filter (c/time-left? context 60000) (query-lahetettavat))]
     (when (seq lahetettavat)
       (doseq [herate lahetettavat]
         (->> herate
              (send-sms-and-return-status!)
-             (update-status-in-db! herate))))))
+             (update-status-in-db! herate))))
+    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää SMS-viestiä.")))

--- a/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
@@ -87,7 +87,8 @@
   (let [lahetettavat (filter (c/time-left? context 60000) (query-lahetettavat))]
     (when (seq lahetettavat)
       (doseq [herate lahetettavat]
-        (->> herate
-             (send-sms-and-return-status!)
-             (update-status-in-db! herate))))
+        (try (->> herate
+                  (send-sms-and-return-status!)
+                  (update-status-in-db! herate))
+             (catch Exception e (log/error e "herätteessä" herate)))))
     (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää SMS-viestiä.")))

--- a/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISSMSHandler.clj
@@ -86,6 +86,7 @@
   (cl/log-caller-details-scheduled "AMISSMSHandler" event context)
   (let [lahetettavat (query-lahetettavat)
         timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count lahetettavat) "SMS-viestiä.")
     (when (seq lahetettavat)
       (c/doseq-with-timeout
         timeout?
@@ -93,5 +94,4 @@
         (try (->> herate
                   (send-sms-and-return-status!)
                   (update-status-in-db! herate))
-             (catch Exception e (log/error e "herätteessä" herate)))))
-    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää SMS-viestiä.")))
+             (catch Exception e (log/error e "herätteessä" herate)))))))

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -207,5 +207,6 @@
   (let [lahetettavat (filter (c/time-left? context 60000) (do-query))]
     (when (seq lahetettavat)
       (doseq [lahetettava lahetettavat]
-        (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))))
+        (try (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))
+             (catch Exception e (log/error e "herätteessä" lahetettava)))))
     (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -204,8 +204,8 @@
   viestintäpalveluun."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendAMISEmails" event context)
-  (let [lahetettavat (do-query)]
-    (log/info "Käsitellään" (count lahetettavat) "lähetettävää viestiä.")
+  (let [lahetettavat (filter (c/time-left? context 60000) (do-query))]
     (when (seq lahetettavat)
       (doseq [lahetettava lahetettavat]
-        (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))))))
+        (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))))
+    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -166,8 +166,7 @@
   []
   (ddb/query-items {:lahetystila [:eq [:s (:ei-lahetetty c/kasittelytilat)]]
                     :alkupvm     [:le [:s (str (c/local-date-now))]]}
-                   {:index "lahetysIndex"
-                    :limit 10}))
+                   {:index "lahetysIndex"}))
 
 (defn send-email-for-palaute!
   "Lähettää sähköpostia yhden palauteherätteen suhteen (jos tarpeen)."
@@ -205,10 +204,8 @@
   viestintäpalveluun."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendAMISEmails" event context)
-  (loop [lahetettavat (do-query)]
+  (let [lahetettavat (do-query)]
     (log/info "Käsitellään" (count lahetettavat) "lähetettävää viestiä.")
     (when (seq lahetettavat)
       (doseq [lahetettava lahetettavat]
-        (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!)))
-      (when (< 60000 (.getRemainingTimeInMillis context))
-        (recur (do-query))))))
+        (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))))))

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -206,10 +206,10 @@
   (log-caller-details-scheduled "handleSendAMISEmails" event context)
   (let [lahetettavat (do-query)
         timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count lahetettavat) "lähetettävää viestiä.")
     (when (seq lahetettavat)
       (c/doseq-with-timeout
         timeout?
         [lahetettava lahetettavat]
         (try (-> lahetettava (with-kyselylinkki!) (send-email-for-palaute!))
-             (catch Exception e (log/error e "herätteessä" lahetettava)))))
-    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))
+             (catch Exception e (log/error e "herätteessä" lahetettava)))))))

--- a/src/oph/heratepalvelu/amis/EmailStatusHandler.clj
+++ b/src/oph/heratepalvelu/amis/EmailStatusHandler.clj
@@ -73,7 +73,7 @@
   "Päivittää viestintäpalvelussa olevien sähköpostien tilat tietokantaan."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleEmailStatus" event context)
-  (let [heratteet (do-query!)
+  (let [heratteet (filter (c/time-left? context 60000) (do-query!))
         changed? (->> heratteet
                       (map handle-single-herate!)  ; avoid short circuit here
                       (reduce #(or %2 %1) false))]

--- a/src/oph/heratepalvelu/amis/EmailStatusHandler.clj
+++ b/src/oph/heratepalvelu/amis/EmailStatusHandler.clj
@@ -74,8 +74,8 @@
   (log-caller-details-scheduled "handleEmailStatus" event context)
   (let [heratteet (do-query!)
         timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count heratteet) "herätettä")
     (c/doseq-with-timeout
       timeout?
       [herate heratteet]
-      (handle-single-herate! herate))
-    (log/info "Käsiteltiin" (count heratteet) "herätettä")))
+      (handle-single-herate! herate))))

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -330,6 +330,13 @@
       last
       normal)))
 
+(defn time-left?
+  "Tarkoitettu laiskojen sekvenssien filtteröintiin.  Ei päästä elementtejä
+  läpi, mikäli suorituskontekstissa on aikaa liian vähän jäljellä.  Aikaraja
+  annetaan millisekunteina."
+  [^com.amazonaws.services.lambda.runtime.Context context limit]
+  (fn [_] (< (.getRemainingTimeInMillis context) limit)))
+
 (defn- make-set-pair
   "Luo '#x = :x' -pareja update-expreja varten."
   [item-key]

--- a/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
@@ -99,5 +99,5 @@
   "Käsittelee muistettavia nippuja."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendEmailMuistutus" event context)
-  (let [muistutettavat (query-muistutukset)]
-    (sendEmailMuistutus muistutettavat)))
+  (sendEmailMuistutus (filter (c/time-left? context 60000)
+                              (query-muistutukset))))

--- a/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
@@ -70,9 +70,11 @@
 (defn sendEmailMuistutus
   "Käsittelee ryhmää muistutuksia. Hakee niiden statuksia Arvosta ja lähettää
   ne, jos niihin ei ole vastattu ja vastausaika ei ole loppunut."
-  [muistutettavat]
+  [timeout? muistutettavat]
   (log/info "Käsitellään" (count muistutettavat) "lähetettävää muistutusta.")
-  (doseq [nippu muistutettavat]
+  (c/doseq-with-timeout
+    timeout?
+    [nippu muistutettavat]
     (try
       (log/info "Käsitellään kyselylinkki" (:kyselylinkki nippu))
       (let [status (arvo/get-nippulinkki-status (:kyselylinkki nippu))]
@@ -102,5 +104,5 @@
   "Käsittelee muistettavia nippuja."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendEmailMuistutus" event context)
-  (sendEmailMuistutus (filter (c/time-left? context 60000)
-                              (query-muistutukset))))
+  (sendEmailMuistutus (c/no-time-left? context 60000)
+                      (query-muistutukset)))

--- a/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
@@ -71,7 +71,7 @@
   "Käsittelee ryhmää muistutuksia. Hakee niiden statuksia Arvosta ja lähettää
   ne, jos niihin ei ole vastattu ja vastausaika ei ole loppunut."
   [timeout? muistutettavat]
-  (log/info "Käsitellään" (count muistutettavat) "lähetettävää muistutusta.")
+  (log/info "Aiotaan käsitellä" (count muistutettavat) "muistutusta.")
   (c/doseq-with-timeout
     timeout?
     [nippu muistutettavat]

--- a/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/EmailMuistutusHandler.clj
@@ -92,16 +92,12 @@
     {:muistutukset [:eq [:n 0]]
      :lahetyspvm   [:between [[:s (str (.minusDays (c/local-date-now) 10))]
                               [:s (str (.minusDays (c/local-date-now) 5))]]]}
-    {:index "emailMuistutusIndex"
-     :limit 10}
+    {:index "emailMuistutusIndex"}
     (:nippu-table env)))
 
 (defn -handleSendEmailMuistutus
   "Käsittelee muistettavia nippuja."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendEmailMuistutus" event context)
-  (loop [muistutettavat (query-muistutukset)]
-    (sendEmailMuistutus muistutettavat)
-    (when (and (seq muistutettavat)
-               (< 60000 (.getRemainingTimeInMillis context)))
-      (recur (query-muistutukset)))))
+  (let [muistutettavat (query-muistutukset)]
+    (sendEmailMuistutus muistutettavat)))

--- a/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
@@ -22,7 +22,7 @@
   "Hakee jaksot ja oppilaitokset tietokannasta nipun sisällön perusteella ja
   lähettää niistä luodut SMS-muistutukset viestintäpalveluun."
   [timeout? muistutettavat]
-  (log/info (str "Käsitellään" (count muistutettavat) "muistutusta."))
+  (log/info (str "Aiotaan käsitellä" (count muistutettavat) "muistutusta."))
   (c/doseq-with-timeout
     timeout?
     [nippu muistutettavat]

--- a/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
@@ -83,5 +83,4 @@
   "Hakee SMS-muistutettavia nippuja tietokannasta ja lähettää viestejä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendSMSMuistutus" event context)
-  (let [muistutettavat (query-muistutukset)]
-    (sendSmsMuistutus muistutettavat)))
+  (sendSmsMuistutus (filter (c/time-left? context 60000) (query-muistutukset))))

--- a/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
@@ -21,9 +21,11 @@
 (defn sendSmsMuistutus
   "Hakee jaksot ja oppilaitokset tietokannasta nipun sisällön perusteella ja
   lähettää niistä luodut SMS-muistutukset viestintäpalveluun."
-  [muistutettavat]
+  [timeout? muistutettavat]
   (log/info (str "Käsitellään" (count muistutettavat) "muistutusta."))
-  (doseq [nippu muistutettavat]
+  (c/doseq-with-timeout
+    timeout?
+    [nippu muistutettavat]
     (try
       (log/info "Kyselylinkin tunnusosa:"
                 (last (str/split (:kyselylinkki nippu) #"_")))
@@ -71,4 +73,4 @@
   "Hakee SMS-muistutettavia nippuja tietokannasta ja lähettää viestejä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendSMSMuistutus" event context)
-  (sendSmsMuistutus (filter (c/time-left? context 60000) (query-muistutukset))))
+  (sendSmsMuistutus (c/no-time-left? context 60000) (query-muistutukset)))

--- a/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
+++ b/src/oph/heratepalvelu/tep/SMSMuistutusHandler.clj
@@ -76,17 +76,12 @@
                                                             10))]
                                        [:s (str (.minusDays (c/local-date-now)
                                                             5))]]]}
-                   {:index "smsMuistutusIndex"
-                    :limit 10}
+                   {:index "smsMuistutusIndex"}
                    (:nippu-table env)))
 
 (defn -handleSendSMSMuistutus
   "Hakee SMS-muistutettavia nippuja tietokannasta ja lähettää viestejä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendSMSMuistutus" event context)
-  (loop [muistutettavat (query-muistutukset)]
-    (sendSmsMuistutus muistutettavat)
-    (when (and
-            (seq muistutettavat)
-            (< 60000 (.getRemainingTimeInMillis context)))
-      (recur (query-muistutukset)))))
+  (let [muistutettavat (query-muistutukset)]
+    (sendSmsMuistutus muistutettavat)))

--- a/src/oph/heratepalvelu/tep/StatusHandler.clj
+++ b/src/oph/heratepalvelu/tep/StatusHandler.clj
@@ -34,37 +34,34 @@
                  (:nippu-table env))]
     (doseq [email emails]
       (log/info "Päivitetään tila viestintäpalvelussa olevalle nipulle" email)
-      (let [nippu (ddb/get-item {:ohjaaja_ytunnus_kj_tutkinto
-                                 [:s (:ohjaaja_ytunnus_kj_tutkinto email)]
-                                 :niputuspvm [:s (:niputuspvm email)]}
-                                (:nippu-table env))
-            status (vp/get-email-status (:viestintapalvelu-id nippu))
-            tila (vp/viestintapalvelu-status->kasittelytila status)
-            new-loppupvm (tc/get-new-loppupvm nippu)]
-        (if-not tila
-          (log/info "Odottaa lähetystä viestintäpalvelussa:" status)
-          (try
-            (when-not @new-changes? (reset! new-changes? true))
-            (log/info "Päivitetään Arvoon tila" tila "loppupvm" new-loppupvm)
-            (if (or (str/includes? (:kyselylinkki nippu) ",")
-                    (str/includes? (:kyselylinkki nippu) ";"))
-              (log/warn "Kyselylinkissä outoja merkkejä, ei päivitetä Arvoon:"
-                        (:kyselylinkki nippu))
-              (arvo/patch-nippulinkki
-                (:kyselylinkki nippu)
-                (if (and new-loppupvm (= tila (:success c/kasittelytilat)))
-                  {:tila tila :voimassa_loppupvm new-loppupvm}
-                  {:tila tila})))
-            (log/info "Päivitetään tietokantaan tila" tila
-                      "loppupvm" new-loppupvm)
-            (tc/update-nippu
-              nippu
-              {:kasittelytila [:s tila]
-               :voimassaloppupvm [:s (or new-loppupvm
-                                         (:voimassaloppupvm nippu))]})
-            (catch AwsServiceException e
-              (log/error "Lähetystilan tallennus kantaan epäonnistui" nippu)
-              (log/error e))
-            (catch Exception e
-              (log/error "Lähetystilan tallennus Arvoon epäonnistui" nippu)
-              (log/error e))))))))
+      (try
+        (let [nippu (ddb/get-item {:ohjaaja_ytunnus_kj_tutkinto
+                                   [:s (:ohjaaja_ytunnus_kj_tutkinto email)]
+                                   :niputuspvm [:s (:niputuspvm email)]}
+                                  (:nippu-table env))
+              status (vp/get-email-status (:viestintapalvelu-id nippu))
+              tila (vp/viestintapalvelu-status->kasittelytila status)
+              new-loppupvm (tc/get-new-loppupvm nippu)]
+          (if-not tila
+            (log/info "Odottaa lähetystä viestintäpalvelussa:" status)
+            (do
+              (when-not @new-changes? (reset! new-changes? true))
+              (log/info "Päivitetään Arvoon tila" tila "loppupvm" new-loppupvm)
+              (if (or (str/includes? (:kyselylinkki nippu) ",")
+                      (str/includes? (:kyselylinkki nippu) ";"))
+                (log/warn "Kyselylinkissä outoja merkkejä, ei päivitetä Arvoon:"
+                          (:kyselylinkki nippu))
+                (arvo/patch-nippulinkki
+                  (:kyselylinkki nippu)
+                  (if (and new-loppupvm (= tila (:success c/kasittelytilat)))
+                    {:tila tila :voimassa_loppupvm new-loppupvm}
+                    {:tila tila})))
+              (log/info "Päivitetään tietokantaan tila" tila
+                        "loppupvm" new-loppupvm)
+              (tc/update-nippu
+                nippu
+                {:kasittelytila [:s tila]
+                 :voimassaloppupvm [:s (or new-loppupvm
+                                           (:voimassaloppupvm nippu))]}))))
+        (catch Exception e
+          (log/error e "mailille" email))))))

--- a/src/oph/heratepalvelu/tep/StatusHandler.clj
+++ b/src/oph/heratepalvelu/tep/StatusHandler.clj
@@ -31,8 +31,12 @@
                  {:kasittelytila
                   [:eq [:s (:viestintapalvelussa c/kasittelytilat)]]}
                  {:index "niputusIndex"}
-                 (:nippu-table env))]
-    (doseq [email emails]
+                 (:nippu-table env))
+        timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count emails) "sähköpostiviestiä.")
+    (c/doseq-with-timeout
+      timeout?
+      [email emails]
       (log/info "Päivitetään tila viestintäpalvelussa olevalle nipulle" email)
       (try
         (let [nippu (ddb/get-item {:ohjaaja_ytunnus_kj_tutkinto

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -17,9 +17,8 @@
    työpaikkaohjaajan yhteystietojen poiston."
   [_ _ _]
   (log/info "Käynnistetään jaksojen lähetys")
-  (let [resp (ehoks/get-paattyneet-tyoelamajaksot "2021-07-01"
-                                                  (str (c/local-date-now))
-                                                  1500)]
+  (let [resp (ehoks/get-paattyneet-tyoelamajaksot
+               "2021-07-01" (str (c/local-date-now)) 1500)]
     (log/info "Lähetetty" (:data (:body resp)) "viestiä"))
 
   (log/info "Käynnistetään työpaikkaohjaajan yhteystietojen poisto")

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -108,6 +108,7 @@
   (log-caller-details-scheduled "handleSendTEPEmails" event context)
   (let [lahetettavat (do-nippu-query)
         timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count lahetettavat) "lähetettävää viestiä.")
     (when (seq lahetettavat)
       (c/doseq-with-timeout
         timeout?
@@ -136,5 +137,4 @@
                             "ja lahetyspvm" lahetyspvm
                             "eroavat toisistaan.")))))
           (catch Exception e
-            (log/error e "nipussa" nippu)))))
-    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))
+            (log/error e "nipussa" nippu)))))))

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -51,8 +51,7 @@
   []
   (ddb/query-items {:kasittelytila [:eq [:s (:ei-lahetetty c/kasittelytilat)]]
                     :niputuspvm    [:le [:s (str (c/local-date-now))]]}
-                   {:index "niputusIndex"
-                    :limit 20}
+                   {:index "niputusIndex"}
                    (:nippu-table env)))
 
 (defn email-sent-update-item
@@ -107,7 +106,7 @@
   käsittelee näiden viestien lähettämisen viestinäpalveluun."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendTEPEmails" event context)
-  (loop [lahetettavat (do-nippu-query)]
+  (let [lahetettavat (do-nippu-query)]
     (log/info "Käsitellään" (count lahetettavat) "lähetettävää viestiä.")
     (when (seq lahetettavat)
       (doseq [nippu lahetettavat]
@@ -132,6 +131,4 @@
                 (log/warn "Nipun" (:ohjaaja_ytunnus_kj_tutkinto nippu)
                           "niputuspvm" (:niputuspvm nippu)
                           "ja lahetyspvm" lahetyspvm
-                          "eroavat toisistaan."))))))
-      (when (< 60000 (.getRemainingTimeInMillis context))
-        (recur (do-nippu-query))))))
+                          "eroavat toisistaan.")))))))))

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -106,9 +106,12 @@
   käsittelee näiden viestien lähettämisen viestinäpalveluun."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendTEPEmails" event context)
-  (let [lahetettavat (filter (c/time-left? context 60000) (do-nippu-query))]
+  (let [lahetettavat (do-nippu-query)
+        timeout? (c/no-time-left? context 60000)]
     (when (seq lahetettavat)
-      (doseq [nippu lahetettavat]
+      (c/doseq-with-timeout
+        timeout?
+        [nippu lahetettavat]
         (log/info "Lähetetään nippu" nippu)
         (try
           (let [jaksot (tc/get-jaksot-for-nippu nippu)

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -106,8 +106,7 @@
   käsittelee näiden viestien lähettämisen viestinäpalveluun."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleSendTEPEmails" event context)
-  (let [lahetettavat (do-nippu-query)]
-    (log/info "Käsitellään" (count lahetettavat) "lähetettävää viestiä.")
+  (let [lahetettavat (filter (c/time-left? context 60000) (do-nippu-query))]
     (when (seq lahetettavat)
       (doseq [nippu lahetettavat]
         (log/info "Lähetetään nippu" nippu)
@@ -131,4 +130,5 @@
                 (log/warn "Nipun" (:ohjaaja_ytunnus_kj_tutkinto nippu)
                           "niputuspvm" (:niputuspvm nippu)
                           "ja lahetyspvm" lahetyspvm
-                          "eroavat toisistaan.")))))))))
+                          "eroavat toisistaan.")))))))
+    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -312,8 +312,6 @@
                 :else
                 (save-jaksotunnus herate opiskeluoikeus koulutustoimija))))
           (ehoks/patch-oht-tep-kasitelty (:hankkimistapa-id herate)))
-        (catch JsonParseException e
-          (log/error "Virhe viestin lukemisessa:" e))
         (catch ExceptionInfo e
           (if (and (:status (ex-data e))
                    (= 404 (:status (ex-data e))))
@@ -323,4 +321,6 @@
                                                             true)))
               (log/error "Virhe:" e))
             (do (log/error e)
-                (throw e))))))))
+                (throw e))))
+        (catch Exception e
+          (log/error e "herätteellä" msg))))))

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -340,7 +340,7 @@
   (let [processed-niput (atom {})
         timeout? (c/no-time-left? context 60000)
         niputettavat (sort-by :niputuspvm #(- (compare %1 %2)) (do-query))]
-    (log/info "Käsitellään enintään" (count niputettavat) "niputusta.")
+    (log/info "Aiotaan käsitellä" (count niputettavat) "niputusta.")
     (when (seq niputettavat)
       (c/doseq-with-timeout
         timeout?

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -339,9 +339,9 @@
   (log-caller-details-scheduled "handleNiputus" event context)
   (let [processed-niput (atom {})
         niputettavat (sort-by :niputuspvm #(- (compare %1 %2)) (do-query))]
-    (log/info "Käsitellään" (count niputettavat) "niputusta.")
+    (log/info "Käsitellään enintään" (count niputettavat) "niputusta.")
     (when (seq niputettavat)
-      (doseq [nippu niputettavat]
+      (doseq [nippu (filter (c/time-left? context 60000) niputettavat)]
         (if (get @processed-niput (get-nippu-key nippu))
           (log/warn "Nippu on jo käsitelty" nippu)
           (do (niputa nippu)

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -344,5 +344,7 @@
       (doseq [nippu (filter (c/time-left? context 60000) niputettavat)]
         (if (get @processed-niput (get-nippu-key nippu))
           (log/warn "Nippu on jo käsitelty" nippu)
-          (do (niputa nippu)
-              (swap! processed-niput assoc (get-nippu-key nippu) true)))))))
+          (try (niputa nippu)
+               (swap! processed-niput assoc (get-nippu-key nippu) true)
+               (catch Exception e
+                 (log/error e "nipussa" nippu))))))))

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -324,8 +324,7 @@
   []
   (ddb/query-items {:kasittelytila [:eq [:s (:ei-niputettu c/kasittelytilat)]]
                     :niputuspvm    [:le [:s (str (c/local-date-now))]]}
-                   {:index "niputusIndex"
-                    :limit 10}
+                   {:index "niputusIndex"}
                    (:nippu-table env)))
 
 (defn get-nippu-key
@@ -338,14 +337,12 @@
   "Hakee ja niputtaa niputtamattomat jaksot."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleNiputus" event context)
-  (let [processed-niput (atom {})]
-    (loop [niputettavat (sort-by :niputuspvm #(- (compare %1 %2)) (do-query))]
-      (log/info "Käsitellään" (count niputettavat) "niputusta.")
-      (when (seq niputettavat)
-        (doseq [nippu niputettavat]
-          (if (get @processed-niput (get-nippu-key nippu))
-            (log/warn "Nippu on jo käsitelty" nippu)
-            (do (niputa nippu)
-                (swap! processed-niput assoc (get-nippu-key nippu) true))))
-        (when (< 120000 (.getRemainingTimeInMillis context))
-          (recur (do-query)))))))
+  (let [processed-niput (atom {})
+        niputettavat (sort-by :niputuspvm #(- (compare %1 %2)) (do-query))]
+    (log/info "Käsitellään" (count niputettavat) "niputusta.")
+    (when (seq niputettavat)
+      (doseq [nippu niputettavat]
+        (if (get @processed-niput (get-nippu-key nippu))
+          (log/warn "Nippu on jo käsitelty" nippu)
+          (do (niputa nippu)
+              (swap! processed-niput assoc (get-nippu-key nippu) true)))))))

--- a/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
@@ -201,8 +201,6 @@
 
                 :else
                 (jh/save-jaksotunnus herate opiskeluoikeus koulutustoimija)))))
-        (catch JsonParseException e
-          (log/error "Virhe viestin lukemisessa:" e))
         (catch ExceptionInfo e
           (if (and (:status (ex-data e))
                    (= 404 (:status (ex-data e))))
@@ -212,4 +210,6 @@
                           (parse-string (.getBody msg) true)))
               (log/error "Virhe:" e))
             (do (log/error e)
-                (throw e))))))))
+                (throw e))))
+        (catch Exception e
+          (log/error e "herätteessä" msg))))))

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -92,8 +92,7 @@
   käsittelee viestien lähetystä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "tepSmsHandler" event context)
-  (let [lahetettavat (query-lahetettavat)]
-    (log/info "Käsitellään" (count lahetettavat) "lähetettävää viestiä.")
+  (let [lahetettavat (filter (c/time-left? context 60000) (query-lahetettavat))]
     (when (seq lahetettavat)
       (doseq [nippu lahetettavat]
         (log/info "Lähetetään SMS nipulle" nippu)
@@ -162,4 +161,5 @@
                         (log/error "Server error while sending sms")
                         (log/error e))))
                   (catch Exception e
-                    (log/error "Unhandled exception " e)))))))))))
+                    (log/error "Unhandled exception " e)))))))))
+    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -94,6 +94,7 @@
   (log-caller-details-scheduled "tepSmsHandler" event context)
   (let [lahetettavat (query-lahetettavat)
         timeout? (c/no-time-left? context 60000)]
+    (log/info "Aiotaan käsitellä" (count lahetettavat) "lähetettävää viestiä.")
     (when (seq lahetettavat)
       (c/doseq-with-timeout
         timeout?
@@ -149,5 +150,4 @@
                                 "ja sms-lahetyspvm" lahetyspvm
                                 "eroavat toisistaan.")))))))
           (catch Exception e
-            (log/error e "nipussa" nippu)))))
-    (log/info "Käsiteltiin" (count lahetettavat) "lähetettävää viestiä.")))
+            (log/error e "nipussa" nippu)))))))

--- a/src/oph/heratepalvelu/tep/tepSmsHandler.clj
+++ b/src/oph/heratepalvelu/tep/tepSmsHandler.clj
@@ -92,9 +92,12 @@
   käsittelee viestien lähetystä."
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "tepSmsHandler" event context)
-  (let [lahetettavat (filter (c/time-left? context 60000) (query-lahetettavat))]
+  (let [lahetettavat (query-lahetettavat)
+        timeout? (c/no-time-left? context 60000)]
     (when (seq lahetettavat)
-      (doseq [nippu lahetettavat]
+      (c/doseq-with-timeout
+        timeout?
+        [nippu lahetettavat]
         (try
           (log/info "Lähetetään SMS nipulle" nippu)
           (if (= (:ei-niputettu c/kasittelytilat) (:kasittelytila nippu))

--- a/src/oph/heratepalvelu/tpk/tpkArvoCallHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkArvoCallHandler.clj
@@ -82,7 +82,7 @@
   [_ event ^Context context]
   (log-caller-details-scheduled "handleTpkArvoCalls" event context)
   (loop [scan-results (do-scan)]
-    (log/info "Käsitellään" (count (:items scan-results)) "nippua.")
+    (log/info "Aiotaan käsitellä" (count (:items scan-results)) "nippua.")
     (doseq [nippu (:items scan-results)]
       (when (< 30000 (.getRemainingTimeInMillis context))
         (try (handle-single-nippu! nippu)

--- a/src/oph/heratepalvelu/tpk/tpkArvoCallHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkArvoCallHandler.clj
@@ -85,7 +85,9 @@
     (log/info "Käsitellään" (count (:items scan-results)) "nippua.")
     (doseq [nippu (:items scan-results)]
       (when (< 30000 (.getRemainingTimeInMillis context))
-        (handle-single-nippu! nippu)))
+        (try (handle-single-nippu! nippu)
+             (catch Exception e
+               (log/error e "nipussa" nippu)))))
     (when (and (< 30000 (.getRemainingTimeInMillis context))
                (:last-evaluated-key scan-results))
       (recur (do-scan (:last-evaluated-key scan-results))))))

--- a/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
@@ -151,11 +151,12 @@
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleTpkNiputus" event context)
   (loop [niputettavat (query-niputtamattomat nil)]
-    (log/info "Käsitellään" (count (:items niputettavat)) "työpaikkajaksoa")
-    (doseq [jakso (:items niputettavat)]
-      (try (handle-jakso! jakso)
-           (catch Exception e
-             (log/error e "jaksossa" jakso))))
-    (when (and (< 30000 (.getRemainingTimeInMillis context))
-               (:last-evaluated-key niputettavat))
-      (recur (query-niputtamattomat (:last-evaluated-key niputettavat))))))
+    (let [jaksot (:items niputettavat)]
+      (log/info "Aiotaan käsitellä" (count jaksot) "työpaikkajaksoa.")
+      (doseq [jakso jaksot]
+        (try (handle-jakso! jakso)
+             (catch Exception e
+               (log/error e "jaksossa" jakso))))
+      (when (and (< 30000 (.getRemainingTimeInMillis context))
+                 (:last-evaluated-key niputettavat))
+        (recur (query-niputtamattomat (:last-evaluated-key niputettavat)))))))

--- a/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
@@ -152,7 +152,10 @@
   (log-caller-details-scheduled "handleTpkNiputus" event context)
   (loop [niputettavat (query-niputtamattomat nil)]
     (log/info "Käsitellään" (count (:items niputettavat)) "työpaikkajaksoa")
-    (doseq [jakso (:items niputettavat)] (handle-jakso! jakso))
+    (doseq [jakso (:items niputettavat)]
+      (try (handle-jakso! jakso)
+           (catch Exception e
+             (log/error e "jaksossa" jakso))))
     (when (and (< 30000 (.getRemainingTimeInMillis context))
                (:last-evaluated-key niputettavat))
       (recur (query-niputtamattomat (:last-evaluated-key niputettavat))))))

--- a/test/oph/heratepalvelu/amis/AMISMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISMuistutusHandler_test.clj
@@ -106,6 +106,8 @@
   (reset! test-sendAMISMuistutus-results
           (str @test-sendAMISMuistutus-results email " " n " " status " ")))
 
+(defn- timeout? [] false)
+
 (deftest test-sendAMISMuistutus
   (testing "Varmista, että sendAMISMuistutus kutsuu muita funktioita oikein"
     (with-redefs
@@ -133,16 +135,20 @@
             expected4 (str "{:kyselylinkki \"kysely.linkki/4\"} 1 "
                            "{:vastattu true, "
                            ":voimassa_loppupvm \"2021-10-10\"} ")]
-        (mh/sendAMISMuistutus muistutettavat1 1)
+        ;; timeout case
+        (mh/sendAMISMuistutus (fn [] true) muistutettavat1 1)
+        (is (= @test-sendAMISMuistutus-results ""))
+        ;; normal cases
+        (mh/sendAMISMuistutus timeout? muistutettavat1 1)
         (is (= @test-sendAMISMuistutus-results expected1))
         (reset! test-sendAMISMuistutus-results "")
-        (mh/sendAMISMuistutus muistutettavat2 1)
+        (mh/sendAMISMuistutus timeout? muistutettavat2 1)
         (is (= @test-sendAMISMuistutus-results expected2))
         (reset! test-sendAMISMuistutus-results "")
-        (mh/sendAMISMuistutus muistutettavat3 1)
+        (mh/sendAMISMuistutus timeout? muistutettavat3 1)
         (is (= @test-sendAMISMuistutus-results expected3))
         (reset! test-sendAMISMuistutus-results "")
-        (mh/sendAMISMuistutus muistutettavat4 1)
+        (mh/sendAMISMuistutus timeout? muistutettavat4 1)
         (is (= @test-sendAMISMuistutus-results expected4))))))
 
 (def mock-query-items-results (atom {}))

--- a/test/oph/heratepalvelu/amis/AMISMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISMuistutusHandler_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [oph.heratepalvelu.amis.AMISMuistutusHandler :as mh]
             [oph.heratepalvelu.common :as c]
-            [oph.heratepalvelu.external.viestintapalvelu :as vp]
-            [oph.heratepalvelu.test-util :as tu])
+            [oph.heratepalvelu.external.viestintapalvelu :as vp])
   (:import (java.time LocalDate)))
 
 (def mock-update-after-send-results (atom {}))
@@ -175,25 +174,3 @@
         (is (= @mock-query-items-results expected-1))
         (mh/query-muistutukset 2)
         (is (= @mock-query-items-results expected-2))))))
-
-(def test-handleSendAMISMuistutus-results (atom ""))
-
-(defn- mock-query-muistutukset [n] {:fake-muistutus-level n})
-
-(defn- mock-sendAMISMuistutus [muistutettavat n]
-  (when (= n (:fake-muistutus-level muistutettavat))
-    (reset!
-      test-handleSendAMISMuistutus-results
-      (str @test-handleSendAMISMuistutus-results "muistutus-level " n " "))))
-
-(deftest test-handleSendAMISMuistutus
-  (testing "Varmista, että -handleSendAMISMuistutus kutsuu funktioita oikein"
-    (with-redefs [oph.heratepalvelu.amis.AMISMuistutusHandler/query-muistutukset
-                  mock-query-muistutukset
-                  oph.heratepalvelu.amis.AMISMuistutusHandler/sendAMISMuistutus
-                  mock-sendAMISMuistutus]
-      (let [event (tu/mock-handler-event :scheduledherate)
-            context (tu/mock-handler-context)
-            expected "muistutus-level 1 muistutus-level 2 "]
-        (mh/-handleSendAMISMuistutus {} event context)
-        (is (= @test-handleSendAMISMuistutus-results expected))))))

--- a/test/oph/heratepalvelu/amis/AMISSMSHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISSMSHandler_test.clj
@@ -19,7 +19,7 @@
                   oph.heratepalvelu.db.dynamodb/query-items-with-expression
                   mock-query-items
                   environ.core/env {:herate-table "herate-table-name"}]
-      (is (= (ash/query-lahetettavat 20)
+      (is (= (ash/query-lahetettavat)
              {:params "#smstila = :tila AND #alku <= :pvm"
               :options
               {:index "smsIndex"
@@ -28,16 +28,15 @@
                                  "#alku" "alkupvm",
                                  "#linkki" "kyselylinkki"}
                :expr-attr-vals {":tila" [:s "ei_lahetetty"],
-                                ":pvm" [:s "2022-03-03"]}
-               :limit 20}
+                                ":pvm" [:s "2022-03-03"]}}
               :table "herate-table-name"})))))
 
 (def results (atom []))
 
 (defn- add-to-results [object] (reset! results (cons object @results)))
 
-(defn- mock-query-lahetettavat [limit]
-  (add-to-results {:type "mock-query-lahetettavat" :limit limit})
+(defn- mock-query-lahetettavat []
+  (add-to-results {:type "mock-query-lahetettavat"})
   [{:voimassa-loppupvm "2022-02-02"}
    {:voimassa-loppupvm "2022-04-04"
     :puhelinnumero "lkj12hl34kj1hl3412"}
@@ -71,7 +70,7 @@
                   oph.heratepalvelu.external.organisaatio/get-organisaatio
                   mock-get-organisaatio
                   oph.heratepalvelu.external.elisa/send-sms mock-send-sms]
-      (let [expected [{:type "mock-query-lahetettavat" :limit 20}
+      (let [expected [{:type "mock-query-lahetettavat"}
                       {:type "mock-update-herate"
                        :herate {:voimassa-loppupvm "2022-02-02"}
                        :options {:sms-lahetyspvm [:s "2022-03-03"]

--- a/test/oph/heratepalvelu/amis/AMISherateEmailHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISherateEmailHandler_test.clj
@@ -112,8 +112,7 @@
        (= :le (first (:alkupvm query-params)))
        (= :s (first (second (:alkupvm query-params))))
        (= "2021-10-10" (second (second (:alkupvm query-params))))
-       (= "lahetysIndex" (:index options))
-       (= 10 (:limit options))))
+       (= "lahetysIndex" (:index options))))
 
 (deftest test-do-query
   (testing "Varmista, että do-query kutsuu query-items oikein"

--- a/test/oph/heratepalvelu/amis/EmailStatusHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/EmailStatusHandler_test.clj
@@ -78,8 +78,7 @@
                (= :s (first (second (:lahetystila query-params))))
                (= (:viestintapalvelussa c/kasittelytilat)
                   (second (second (:lahetystila query-params))))
-               (= "lahetysIndex" (:index options))
-               (= 10 (:limit options)))))
+               (= "lahetysIndex" (:index options)))))
 
 (deftest test-do-query!
   (testing "Varmista, että do-query! kutsuu query-items oikein"

--- a/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
@@ -191,7 +191,6 @@
              (= :s (first (first (second (:lahetyspvm query-params)))))
              (= :s (first (second (second (:lahetyspvm query-params)))))
              (= "emailMuistutusIndex" (:index options))
-             (= 10 (:limit options))
              (= "nippu-table-name" table))
     {:start-date (second (first (second (:lahetyspvm query-params))))
      :end-date (second (second (second (:lahetyspvm query-params))))}))

--- a/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
@@ -177,7 +177,7 @@
              (str "update-item-cannot-answer: "
                   "{:kyselylinkki \"kysely.linkki/xyz_GHKJJK\"} "
                   "{:vastattu false, :voimassa_loppupvm \"2021-10-08\"}")]]
-        (emh/sendEmailMuistutus muistutettavat)
+        (emh/sendEmailMuistutus (fn [] false) muistutettavat)
         (is (= @test-sendEmailMuistutus-call-log (reverse expected-call-log)))
         (is (tu/logs-contain?
               {:level :info
@@ -207,7 +207,7 @@
 
 (defn- mock-query-muistutukset [] [{:muistutus-contents "test-data"}])
 
-(defn- mock-sendEmailMuistutus [muistutettavat]
+(defn- mock-sendEmailMuistutus [_ muistutettavat]
   (reset! test-handleSendEmailMuistutus-result
           {:muistutettavat muistutettavat}))
 

--- a/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/EmailMuistutusHandler_test.clj
@@ -180,8 +180,7 @@
         (emh/sendEmailMuistutus (fn [] false) muistutettavat)
         (is (= @test-sendEmailMuistutus-call-log (reverse expected-call-log)))
         (is (tu/logs-contain?
-              {:level :info
-               :message "Käsitellään 3 lähetettävää muistutusta."}))))))
+              {:level :info :message "Aiotaan käsitellä 3 muistutusta."}))))))
 
 (defn- mock-query-items [query-params options table]
   (when (and (= :eq (first (:muistutukset query-params)))

--- a/test/oph/heratepalvelu/tep/SMSMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/SMSMuistutusHandler_test.clj
@@ -117,7 +117,7 @@
                       :updates {:sms_kasittelytila
                                 [:s (:vastausaika-loppunut-m c/kasittelytilat)]
                                 :sms_muistutukset [:n 1]}}]]
-        (smh/sendSmsMuistutus muistutettavat)
+        (smh/sendSmsMuistutus (fn [] false) muistutettavat)
         (is (= results (vec (reverse @test-sendSmsMuistutus-results))))))))
 
 (defn- mock-query-muistutukset-query-items [query-params options table]
@@ -150,7 +150,7 @@
                 @test-handleSendSMSMuistutus-results))
   [{:type "Muistutettava"}])
 
-(defn- mock-sendSmsMuistutus [muistutettavat]
+(defn- mock-sendSmsMuistutus [_ muistutettavat]
   (reset! test-handleSendSMSMuistutus-results
           (cons {:type "mock-sendSmsMuistutus"
                  :value muistutettavat}

--- a/test/oph/heratepalvelu/tep/SMSMuistutusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/SMSMuistutusHandler_test.clj
@@ -131,7 +131,6 @@
        (= "2021-12-10"
           (second (second (second (:sms_lahetyspvm query-params)))))
        (= "smsMuistutusIndex" (:index options))
-       (= 10 (:limit options))
        (= "nippu-table-name" table)))
 
 (deftest test-query-muistutukset

--- a/test/oph/heratepalvelu/tep/StatusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/StatusHandler_test.clj
@@ -46,8 +46,7 @@
                 (second (second (:kasittelytila query-params))))
              (= "niputusIndex" (:index options))
              (= "nippu-table-name" table))
-    (add-to-test-results {:type "mock-query-items"
-                          :limit (:limit options)})
+    (add-to-test-results {:type "mock-query-items"})
     [{:ohjaaja_ytunnus_kj_tutkinto "test-id-1"
       :niputuspvm "2021-12-15"}
      {:ohjaaja_ytunnus_kj_tutkinto "test-id-2"
@@ -88,8 +87,7 @@
                   mock-update-nippu]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
-            results [{:type "mock-query-items"
-                      :limit 100}
+            results [{:type "mock-query-items"}
                      {:type "mock-get-item"
                       :value "test-id-1"}
                      {:type "mock-get-email-status" :id 1}

--- a/test/oph/heratepalvelu/tep/emailHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/emailHandler_test.clj
@@ -92,7 +92,6 @@
              (= :le (first (:niputuspvm query-params)))
              (= :s (first (second (:niputuspvm query-params))))
              (= "niputusIndex" (:index options))
-             (= 20 (:limit options))
              (= "nippu-table-name" table))
     (reset! test-do-nippu-query-results
             (second (second (:niputuspvm query-params))))))

--- a/test/oph/heratepalvelu/tep/emailHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/emailHandler_test.clj
@@ -249,7 +249,8 @@
        mock-get-oppilaitokset]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
-            expected-call-log ["do-nippu-query"
+            expected-call-log ["do-nippu-query"  ; from timeout case
+                               "do-nippu-query"
                                "get-jaksot-for-nippu: email-1"
                                (str "get-oppilaitokset: "
                                     "[{:oppilaitos \"123.456.789\"}]")
@@ -272,6 +273,10 @@
                                     "[{:oppilaitos \"123.456.789\"}]")
                                (str "lahetysosoite: email-3 "
                                     "[{:oppilaitos \"123.456.789\"}]")]]
+        ;; timeout case
+        (eh/-handleSendTEPEmails {} event (tu/mock-handler-context 100))
+        (is (= @test-handleSendTEPEmails-call-log ["do-nippu-query"]))
+        ;; normal case
         (eh/-handleSendTEPEmails {} event context)
         (is (= @test-handleSendTEPEmails-call-log (reverse expected-call-log)))
         (is (true? (tu/logs-contain?

--- a/test/oph/heratepalvelu/tep/emailHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/emailHandler_test.clj
@@ -276,4 +276,4 @@
         (is (= @test-handleSendTEPEmails-call-log (reverse expected-call-log)))
         (is (true? (tu/logs-contain?
                      {:level :info
-                      :message "Käsitellään 3 lähetettävää viestiä."})))))))
+                      :message "Käsiteltiin 3 lähetettävää viestiä."})))))))

--- a/test/oph/heratepalvelu/tep/emailHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/emailHandler_test.clj
@@ -279,6 +279,6 @@
         ;; normal case
         (eh/-handleSendTEPEmails {} event context)
         (is (= @test-handleSendTEPEmails-call-log (reverse expected-call-log)))
-        (is (true? (tu/logs-contain?
-                     {:level :info
-                      :message "Käsiteltiin 3 lähetettävää viestiä."})))))))
+        (is (tu/logs-contain?
+              {:level :info
+               :message "Aiotaan käsitellä 3 lähetettävää viestiä."}))))))

--- a/test/oph/heratepalvelu/tep/niputusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/niputusHandler_test.clj
@@ -779,7 +779,6 @@
              (= :le (first (:niputuspvm query-params)))
              (= :s (first (second (:niputuspvm query-params))))
              (= "niputusIndex" (:index options))
-             (= 10 (:limit options))
              (= "nippu-table-name" table))
     (add-to-handler-results
       {:type "mock-handler-query-items"

--- a/test/oph/heratepalvelu/tep/tepSmsHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/tepSmsHandler_test.clj
@@ -200,8 +200,8 @@
                   (fn [] (LocalDate/of 2021 12 15))
                   oph.heratepalvelu.db.dynamodb/query-items
                   mock-query-lahetettavat-query-items]
-      (sh/query-lahetettavat 10)
-      (is (= @test-query-lahetettavat-results {:limit 10
+      (sh/query-lahetettavat)
+      (is (= @test-query-lahetettavat-results {:limit nil
                                                :niputuspvm "2021-12-15"})))))
 
 (def test-handleTepSmsSending-results (atom []))
@@ -254,9 +254,8 @@
      :kyselylinkki kyselylinkki
      :data data}))
 
-(defn- mock-query-lahetettavat [limit]
-  (add-to-test-handleTepSmsSending-results {:type "mock-query-lahetettavat"
-                                            :limit limit})
+(defn- mock-query-lahetettavat []
+  (add-to-test-handleTepSmsSending-results {:type "mock-query-lahetettavat"})
   [{:ohjaaja_ytunnus_kj_tutkinto "test-id-0"
     :niputuspvm "2021-12-15"
     :voimassaloppupvm "2021-12-20"
@@ -303,8 +302,7 @@
        mock-handleTepSmsSending-update-status-to-db]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
-            results [{:type "mock-query-lahetettavat"
-                      :limit 20}
+            results [{:type "mock-query-lahetettavat"}
                      {:type (str "mock-handleTepSmsSending-update-vastausaika"
                                  "-loppunut-to-db")
                       :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id-0"

--- a/test/oph/heratepalvelu/test_util.clj
+++ b/test/oph/heratepalvelu/test_util.clj
@@ -93,7 +93,7 @@
     event))
 
 (defn mock-handler-context
-  ([] (mock-handler-context 100))
+  ([] (mock-handler-context 100000))
   ([milliseconds]
    (reify com.amazonaws.services.lambda.runtime.Context
      (getAwsRequestId [this] dummy-request-id)


### PR DESCRIPTION
## Kuvaus muutoksista

Jotta virhetilanteet eivät aiheuttaisi koskaan handlerin jumittumista, tämä PR uudelleenstrukturoi koodin siten, ettei yhden handlerin suorituskerran aikana koskaan haeta tietokannasta samaa tietuetta useampaa kertaa.  Tämä avaa virheenkäsittelyyn uuden mahdollisuuden, että virhe vain lokitetaan ja jätetään huomiotta, ja siirrytään seuraavaan tietueeseen.

https://jira.eduuni.fi/browse/EH-1519

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
