### PR TITLE
Uusinta- ja raportointilogiikka kaikkiin HTTP-kyselyihin

### DIFF
--- a/src/oph/heratepalvelu/external/cas_client.clj
+++ b/src/oph/heratepalvelu/external/cas_client.clj
@@ -5,8 +5,7 @@
             [clj-cas.client :as cl]
             [environ.core :refer [env]]
             [cheshire.core :as json]
-            [clj-http.client :refer [request]]
-            [oph.heratepalvelu.external.aws-xray :refer [wrap-aws-xray]]
+            [oph.heratepalvelu.external.http-client :refer [request]]
             [oph.heratepalvelu.external.aws-ssm :as ssm])
   (:import (fi.vm.sade.utils.cas CasClient
                                  CasParams
@@ -84,14 +83,12 @@
 (defn cas-authenticated-get
   "Tekee Cas-autentikoidun GET-requestin."
   [url & [options]]
-  (wrap-aws-xray url :get
-                 #(cas-http :get url options nil)))
+  (cas-http :get url options nil))
 
 (defn cas-authenticated-post
   "Tekee Cas-autentikoidun POST-requestin."
   [url body & [options]]
-  (wrap-aws-xray url :post
-                 #(cas-http :post url options body)))
+  (cas-http :post url options body))
 
 (defn- get-uri
   "Muuttaa stringin Uri-objektiksi."

--- a/src/oph/heratepalvelu/external/http_client.clj
+++ b/src/oph/heratepalvelu/external/http_client.clj
@@ -3,6 +3,7 @@
   (:refer-clojure :exclude [get])
   (:require [clj-http.client :as client]
             [environ.core :refer [env]]
+            [clojure.tools.logging :as log]
             [oph.heratepalvelu.external.aws-xray :refer [wrap-aws-xray]]))
 
 (def client-options
@@ -19,11 +20,50 @@
   (merge (update-in client-options [:headers] merge (:headers options))
          (dissoc options :headers)))
 
+(def temporary-conditions
+  #{java.net.SocketTimeoutException java.net.ConnectException
+    ; these should not be temporary but often are
+    400 401 404 500
+    ; these are allowed to be temporary
+    408 425 429 502 503 504
+    ; these are non-standard extensions; probably doesn't do harm to include
+    520 521 522 524 529 598 599})
+
+(defn temporary-error?
+  "Kertoo poikkeuksesta, voiko sen aiheuttaja olla väliaikainen."
+  [e]
+  (contains? temporary-conditions (or (:status (ex-data e)) (type e))))
+
+(defn request-with-retries
+  "Tekee HTTP-kutsun enintään 3 kertaa siten, että samaa kutsua yritetään
+  uudestaan, mikäli se epäonnistuu tavalla joka saattaa olla väliaikainen.
+  Raportoi epäonnistuneet kutsut."
+  [options]
+  (loop [retries 2]
+    (if (or (:no-retries options) (<= retries 0))
+      (try (client/request options)
+           (catch Exception e
+             (log/error e "while doing" options ", not retrying")
+             (throw e)))
+      (let [result (try (client/request options) (catch Exception e e))]
+        (cond
+          (not (instance? Exception result)) result
+
+          (temporary-error? result)
+          (do (log/info "Got temporary error" (:status (ex-data result))
+                        "/" (.getName ^Class (type result))
+                        "; retrying" retries "times")
+              (recur (dec retries)))
+
+          :else
+          (do (log/error result "while doing request" options)
+              (throw result)))))))
+
 (defn request
   "Tekee HTTP-kutsun X-Rayn avulla."
   [options]
   (wrap-aws-xray (:url options) (:method options)
-                 #(client/request (merge-options options))))
+                 #(request-with-retries (merge-options options))))
 
 (defn method-function
   "Luo HTTP-kyselyfunktion jollekin tietylle HTTP-verbille."

--- a/src/oph/heratepalvelu/external/http_client.clj
+++ b/src/oph/heratepalvelu/external/http_client.clj
@@ -25,26 +25,13 @@
   (wrap-aws-xray (:url options) (:method options)
                  #(client/request (merge-options options))))
 
-(defn get
-  "Tekee GET-kyselyn X-Rayn clj-http clientin kautta."
-  [url & [options]]
-  (wrap-aws-xray url :get
-                 #(client/get url (merge-options options))))
+(defn method-function
+  "Luo HTTP-kyselyfunktion jollekin tietylle HTTP-verbille."
+  [method]
+  (fn [url & [options]]
+    (request (merge {:url url :method method} options))))
 
-(defn post
-  "Tekee POST-kyselyn X-Rayn clj-http clientin kautta."
-  [url & [options]]
-  (wrap-aws-xray url :post
-                 #(client/post url (merge-options options))))
-
-(defn delete
-  "Tekee DELETE-kyselyn X-Rayn clj-http clientin kautta."
-  [url & [options]]
-  (wrap-aws-xray url :delete
-                 #(client/delete url (merge-options options))))
-
-(defn patch
-  "Tekee PATCH-kyselyn X-Rayn clj-http clientin kautta."
-  [url & [options]]
-  (wrap-aws-xray url :patch
-                 #(client/patch url (merge-options options))))
+(def get (method-function :get))
+(def post (method-function :post))
+(def delete (method-function :delete))
+(def patch (method-function :patch))

--- a/src/oph/heratepalvelu/external/http_client.clj
+++ b/src/oph/heratepalvelu/external/http_client.clj
@@ -19,6 +19,12 @@
   (merge (update-in client-options [:headers] merge (:headers options))
          (dissoc options :headers)))
 
+(defn request
+  "Tekee HTTP-kutsun X-Rayn avulla."
+  [options]
+  (wrap-aws-xray (:url options) (:method options)
+                 #(client/request (merge-options options))))
+
 (defn get
   "Tekee GET-kyselyn X-Rayn clj-http clientin kautta."
   [url & [options]]

--- a/src/oph/heratepalvelu/external/http_client.clj
+++ b/src/oph/heratepalvelu/external/http_client.clj
@@ -43,7 +43,8 @@
     (if (or (:no-retries options) (<= retries 0))
       (try (client/request options)
            (catch Exception e
-             (log/error e "while doing" options ", not retrying")
+             (log/error e "error" (ex-data e)
+                        "for request" options ", not retrying")
              (throw e)))
       (let [result (try (client/request options) (catch Exception e e))]
         (cond
@@ -56,7 +57,7 @@
               (recur (dec retries)))
 
           :else
-          (do (log/error result "while doing request" options)
+          (do (log/error result "error" (ex-data result) "for request" options)
               (throw result)))))))
 
 (defn request

--- a/test/oph/heratepalvelu/external/http_client_test.clj
+++ b/test/oph/heratepalvelu/external/http_client_test.clj
@@ -22,15 +22,13 @@
 (defn- mock-wrap-aws-xray [url method request-func]
   {:url url :method method :request-func-result (request-func)})
 
-(defn- generate-mock-client-method [method-name]
-  (fn [url options] {:method-name method-name :url url :options options}))
+(defn mock-http-request [options]
+  {:method-name (:method options) :url (:url options)
+   :options (dissoc options :method :url)})
 
 (deftest test-method-calls
   (testing "Varmista, että http-client metodit toimivat oikein"
-    (with-redefs [clj-http.client/delete (generate-mock-client-method :delete)
-                  clj-http.client/get (generate-mock-client-method :get)
-                  clj-http.client/patch (generate-mock-client-method :patch)
-                  clj-http.client/post (generate-mock-client-method :post)
+    (with-redefs [clj-http.client/request mock-http-request
                   oph.heratepalvelu.external.aws-xray/wrap-aws-xray
                   mock-wrap-aws-xray
                   oph.heratepalvelu.external.http-client/client-options


### PR DESCRIPTION
## Kuvaus muutoksista

Kun herätepalvelu tekee ulkoisia HTTP-kutsuja, ne voivat epäonnistua monista ennalta arvaamattomista syistä.  Tämä PR tekee kaksi asiaa:
 1. lisää toimintavarmuutta kokeilemalla kutsua uudelleen silloin, kun virhe saattaa olla väliaikaista laatua.
 2. helpottaa virheenselvittelyä lokittamalla aina kutsun epäonnistuessa, mitä kutsua oltiin tekemässä.

https://jira.eduuni.fi/browse/EH-1479

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [x] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [x] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [x] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [x] Muutokset on testattu QA-ympäristössä
  - [x] Yli jääneet kehityskohteet on tiketöity
