### PR TITLE
Send missing osaamisala to Arvo as an empty list

### DIFF
--- a/src/oph/heratepalvelu/external/arvo.clj
+++ b/src/oph/heratepalvelu/external/arvo.clj
@@ -66,22 +66,17 @@
 (defn get-osaamisalat
   "Hakee voimassa olevat osaamisalat suorituksesta."
   [suoritus opiskeluoikeus-oid]
-  (let [osaamisalat (filter
-                      #(and
-                         (or (nil? (:loppu %1))
-                             (>= (compare (:loppu %1)
-                                          (str (c/local-date-now)))
-                                 0))
-                         (or (nil? (:alku %1))
-                             (<= (compare (:alku %1)
-                                          (str (c/local-date-now)))
-                                 0)))
-                      (:osaamisala suoritus))]
-    (if (not-empty osaamisalat)
-      (map #(or (:koodiarvo (:osaamisala %1))
-                (:koodiarvo %1))
-           osaamisalat)
-      (log/info "Ei osaamisaloja opiskeluoikeudessa" opiskeluoikeus-oid))))
+  (->> (:osaamisala suoritus)
+       (filter #(and (or (nil? (:loppu %1))
+                         (>= (compare (:loppu %1)
+                                      (str (c/local-date-now)))
+                             0))
+                     (or (nil? (:alku %1))
+                         (<= (compare (:alku %1)
+                                      (str (c/local-date-now)))
+                             0))))
+       (map #(or (:koodiarvo (:osaamisala %1))
+                 (:koodiarvo %1)))))
 
 (defn get-hankintakoulutuksen-toteuttaja
   "Hakee hankintakoulutuksen toteuttajan OID:n eHOKS-palvelusta ja Koskesta."

--- a/test/oph/heratepalvelu/external/arvo_test.clj
+++ b/test/oph/heratepalvelu/external/arvo_test.clj
@@ -63,7 +63,7 @@
                                     :koodiarvo "lkhlkhjl"}]}
             expected ["test1" "test2"]]
         (is (= (arvo/get-osaamisalat suoritus "1.2.3.4") expected))
-        (is (nil? (arvo/get-osaamisalat {:osaamisala []} "1.2.3.4")))))))
+        (is (empty? (arvo/get-osaamisalat {:osaamisala []} "1.2.3.4")))))))
 
 (deftest test-get-hankintakoulutuksen-toteuttaja
   (testing "Get hoks hankintakoulutuksen toteuttaja"

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISherateEmailHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISherateEmailHandler_i_test.clj
@@ -270,7 +270,7 @@
     :options
     {:content-type "application/json"
      :body (str "{\"vastaamisajan_alkupvm\":\"2022-01-15\","
-                "\"osaamisala\":null,\"heratepvm\":\"2022-01-15\","
+                "\"osaamisala\":[],\"heratepvm\":\"2022-01-15\","
                 "\"koulutustoimija_oid\":null,"
                 "\"tutkinnon_suorituskieli\":\"fi\",\"toimipiste_oid\":null,"
                 "\"oppilaitos_oid\":null,"

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -351,7 +351,7 @@
                              :vastaamisajan_alkupvm "2021-12-16"
                              :tyonantaja "765432-1"
                              :oppisopimuksen_perusta nil
-                             :osaamisala nil
+                             :osaamisala []
                              :koulutustoimija_oid "koulutustoimija-id"
                              :paikallinen_tutkinnon_osa nil
                              :tyopaikkajakson_alkupvm "2021-09-09"
@@ -374,7 +374,7 @@
                              :vastaamisajan_alkupvm "2021-12-16"
                              :tyonantaja "111111-1"
                              :oppisopimuksen_perusta nil
-                             :osaamisala nil
+                             :osaamisala []
                              :koulutustoimija_oid "koulutustoimija-id"
                              :paikallinen_tutkinnon_osa nil
                              :tyopaikkajakson_alkupvm "2021-09-09"
@@ -397,7 +397,7 @@
                              :vastaamisajan_alkupvm "2021-12-16"
                              :tyonantaja "123456-7"
                              :oppisopimuksen_perusta nil
-                             :osaamisala nil
+                             :osaamisala []
                              :koulutustoimija_oid "koulutustoimija-id"
                              :paikallinen_tutkinnon_osa nil
                              :tyopaikkajakson_alkupvm "2021-09-09"


### PR DESCRIPTION
## Kuvaus muutoksista

Arvon kanssa sovittiin, että osaamisala-kenttä muuttuu "pakolliseksi", siis se ei saa olla `null`, vaikka saakin olla tyhjä lista.  Tämä vaatii muutoksen Herätepalvelun koodissa.

https://jira.eduuni.fi/browse/EH-1332

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
