### PR TITLE
OY-4444: TUVA-opiskeluoikeuden tarkistus

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISherateHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateHandler.clj
@@ -40,8 +40,9 @@
         (not (some? opiskeluoikeus))
         (log/error "Ei löytynyt opiskeluoikeutta:" summary)
 
-        (not (has-one-or-more-ammatillinen-tutkinto? opiskeluoikeus))
-        (log/warn "Ei tallenneta, opiskeluoikeus ei ammatillinen:" summary)
+        (not (has-one-or-more-ammatillisen-tutkinnon-suoritus? opiskeluoikeus))
+        (log/warn "Ei tallenneta, opiskeluoikeudessa ei yhtään ammatillisen "
+                  "tutkinnon suoritusta:" summary)
 
         (not (whitelisted-organisaatio?!
                koulutustoimija (date-string-to-timestamp (:alkupvm herate))))

--- a/src/oph/heratepalvelu/amis/AMISherateHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateHandler.clj
@@ -40,6 +40,10 @@
         (not (some? opiskeluoikeus))
         (log/error "Ei löytynyt opiskeluoikeutta:" summary)
 
+        (tuva-opiskeluoikeus? opiskeluoikeus)
+        (log/warn "Ei tallenneta, opiskeluoikeus kuuluu TUVA-opiskelijalle, "
+                  "jolloin opinnoista ei kerätä palautetta:" summary)
+
         (not (has-one-or-more-ammatillisen-tutkinnon-suoritus? opiskeluoikeus))
         (log/warn "Ei tallenneta, opiskeluoikeudessa ei yhtään ammatillisen "
                   "tutkinnon suoritusta:" summary)

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -35,7 +35,7 @@
   sellainen on olemassa."
   [opiskeluoikeus]
   (or
-    (some #(and (ammatillinen-tutkinto? %)
+    (some #(and (ammatillisen-tutkinnon-suoritus? %)
                 (get-in % [:vahvistus :päivä]))
           (:suoritukset opiskeluoikeus))
     (log/info "Opiskeluoikeudessa" (:oid opiskeluoikeus)

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -168,20 +168,18 @@
       (str year "-" (inc (Integer/parseInt year)))
       (str (dec (Integer/parseInt year)) "-" year))))
 
-(defn ammatillinen-tutkinto?
+(defn ammatillisen-tutkinnon-suoritus?
   "Varmistaa, että suorituksen tyyppi on joko ammatillinen tutkinto tai
   osittainen ammatillinen tutkinto."
   [suoritus]
   (some? (#{"ammatillinentutkinto" "ammatillinentutkintoosittainen"}
           (:koodiarvo (:tyyppi suoritus)))))
 
-(defn has-one-or-more-ammatillinen-tutkinto?
-  "Varmistaa, että opiskeluoikeuden suorituksiin kuuluu vähintään yksi, jonka
-  tyyppi on ammatillinen tutkinto tai osittainen ammatillinen tutkinto."
+(defn has-one-or-more-ammatillisen-tutkinnon-suoritus?
+  "Varmistaa, että opiskeluoikeuden suorituksiin kuuluu vähintään yksi
+  ammatillisen tutkinnon tai osittaisen ammatillisen tutkinnon suoritus."
   [opiskeluoikeus]
-  (some? (or (some ammatillinen-tutkinto? (:suoritukset opiskeluoikeus))
-             (log/info "Väärä suoritustyyppi opiskeluoikeudessa"
-                       (:oid opiskeluoikeus)))))
+  (some? (some ammatillisen-tutkinnon-suoritus? (:suoritukset opiskeluoikeus))))
 
 (defn sisaltyy-toiseen-opiskeluoikeuteen?
   "Palauttaa true, jos opiskeluoikeus sisältyy toiseen opiskeluoikeuteen."
@@ -195,7 +193,8 @@
 (defn get-suoritus
   "Hakee tutkinnon tai tutkinnon osan suorituksen opiskeluoikeudesta."
   [opiskeluoikeus]
-  (first (filter ammatillinen-tutkinto? (:suoritukset opiskeluoikeus))))
+  (first (filter ammatillisen-tutkinnon-suoritus?
+                 (:suoritukset opiskeluoikeus))))
 
 (defn has-nayttotutkintoonvalmistavakoulutus?
   "Tarkistaa, onko opiskeluoikeudessa näyttötutkintoon valmistavan koulutuksen

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -190,6 +190,12 @@
                      "sisältyy toiseen opiskeluoikeuteen.")
            true)))
 
+(defn tuva-opiskeluoikeus?
+  "Palauttaa `true`, jos parametrina annettu `opiskeluoikeus` on
+  TUVA-opiskeluoikeus."
+  [opiskeluoikeus]
+  (= (get-in opiskeluoikeus [:tyyppi :koodiarvo]) "tuva"))
+
 (defn get-suoritus
   "Hakee tutkinnon tai tutkinnon osan suorituksen opiskeluoikeudesta."
   [opiskeluoikeus]

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -298,6 +298,11 @@
                 (fully-keskeytynyt? herate)
                 (log/warn "Jakso on täysin keskeytynyt.")
 
+                (c/tuva-opiskeluoikeus? opiskeluoikeus)
+                (log/warn "Ei tallenneta, opiskeluoikeus `" oo "` kuuluu "
+                          "TUVA-opiskelijalle, jolloin opinnoista ei kerätä "
+                          "palautetta.")
+
                 (not (c/has-one-or-more-ammatillisen-tutkinnon-suoritus?
                        opiskeluoikeus))
                 (log/warn "Ei tallenneta, opiskeluoikeudessa `" oo

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -298,8 +298,10 @@
                 (fully-keskeytynyt? herate)
                 (log/warn "Jakso on täysin keskeytynyt.")
 
-                (not (c/has-one-or-more-ammatillinen-tutkinto? opiskeluoikeus))
-                (log/warn "Ei ole ammatillinen tutkinto:" opiskeluoikeus)
+                (not (c/has-one-or-more-ammatillisen-tutkinnon-suoritus?
+                       opiskeluoikeus))
+                (log/warn "Ei tallenneta, opiskeluoikeudessa `" oo
+                          "` ei yhtään ammatillisen tutkinnon suoritusta.")
 
                 (c/feedback-collecting-prevented? opiskeluoikeus
                                                   (:loppupvm herate))

--- a/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
@@ -193,7 +193,8 @@
                 (jh/fully-keskeytynyt? herate)
                 (log/warn "jakso keskeytynyt:" herate)
 
-                (not (c/has-one-or-more-ammatillinen-tutkinto? opiskeluoikeus))
+                (not (c/has-one-or-more-ammatillisen-tutkinnon-suoritus?
+                       opiskeluoikeus))
                 (log/warn "Tutkinto ei ole ammatillinen:" opiskeluoikeus)
 
                 (c/sisaltyy-toiseen-opiskeluoikeuteen? opiskeluoikeus)

--- a/test/oph/heratepalvelu/amis/AMISherateHandler_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISherateHandler_test.clj
@@ -19,8 +19,9 @@
   (reset! call-log (str @call-log "get-koulutustoimija-oid "))
   (:koulutustoimija-oid opiskeluoikeus))
 
-(defn- mock-has-one-or-more-ammatillinen-tutkinto? [_]
-  (reset! call-log (str @call-log "has-one-or-more-ammatillinen-tutkinto? "))
+(defn- mock-has-one-or-more-ammatillisen-tutkinnon-suoritus? [_]
+  (reset! call-log
+          (str @call-log "has-one-or-more-ammatillisen-tutkinnon-suoritus? "))
   true)
 
 (defn- mock-whitelisted-organisaatio?! [_ _]
@@ -44,8 +45,8 @@
 
                   c/get-koulutustoimija-oid mock-get-koulutustoimija-oid
 
-                  c/has-one-or-more-ammatillinen-tutkinto?
-                  mock-has-one-or-more-ammatillinen-tutkinto?
+                  c/has-one-or-more-ammatillisen-tutkinnon-suoritus?
+                  mock-has-one-or-more-ammatillisen-tutkinnon-suoritus?
 
                   c/whitelisted-organisaatio?! mock-whitelisted-organisaatio?!
 
@@ -62,11 +63,12 @@
         (with-redefs [c/valid-herate-date?
                       mock-check-valid-herate-date-true]
           (hh/-handleAMISherate {} event context)
-          (is (= @call-log (str "get-opiskeluoikeus-catch-404 "
-                                "get-koulutustoimija-oid "
-                                "has-one-or-more-ammatillinen-tutkinto? "
-                                "whitelisted-organisaatio?! "
-                                "sisaltyy-toiseen-opiskeluoikeuteen? ")))
+          (is (= @call-log
+                 (str "get-opiskeluoikeus-catch-404 "
+                      "get-koulutustoimija-oid "
+                      "has-one-or-more-ammatillisen-tutkinnon-suoritus? "
+                      "whitelisted-organisaatio?! "
+                      "sisaltyy-toiseen-opiskeluoikeuteen? ")))
           (is (= @results {:herate {:alkupvm "2021-10-10"
                                     :opiskeluoikeus-oid "1234.5.6678"
                                     :oppija-oid "12345"

--- a/test/oph/heratepalvelu/common_test.clj
+++ b/test/oph/heratepalvelu/common_test.clj
@@ -1,6 +1,6 @@
 (ns oph.heratepalvelu.common-test
   (:require [clojure.test :refer :all]
-            [oph.heratepalvelu.common :refer :all :as c]
+            [oph.heratepalvelu.common :refer :all]
             [oph.heratepalvelu.test-util :refer :all]
             [clj-time.core :as t]
             [clojure.string :as str])
@@ -111,35 +111,36 @@
         opiskeluoikeus-eronnut-tulevaisuudessa false
         opiskeluoikeus-eronnut-paivaa-aiemmin true))))
 
-(deftest test-ammatillinen-tutkinto
+(deftest test-ammatillisen-tutkinnon-suoritus
   (testing "Check suoritus type"
-    (is (false? (ammatillinen-tutkinto? {:tyyppi {:koodiarvo "valma"}})))
-    (is (true? (ammatillinen-tutkinto?
+    (is (false? (ammatillisen-tutkinnon-suoritus?
+                  {:tyyppi {:koodiarvo "valma"}})))
+    (is (true? (ammatillisen-tutkinnon-suoritus?
                  {:tyyppi {:koodiarvo "ammatillinentutkintoosittainen"}})))
-    (is (true? (ammatillinen-tutkinto?
+    (is (true? (ammatillisen-tutkinnon-suoritus?
                  {:tyyppi {:koodiarvo "ammatillinentutkinto"}})))))
 
-(deftest test-ammatillinen-tutkinto?
+(deftest test-ammatillisen-tutkinnon-suoritus?
   (testing "Check suoritus type"
-    (is (not (ammatillinen-tutkinto? {:tyyppi {:koodiarvo "valma"}})))
-    (is (ammatillinen-tutkinto?
+    (is (not (ammatillisen-tutkinnon-suoritus? {:tyyppi {:koodiarvo "valma"}})))
+    (is (ammatillisen-tutkinnon-suoritus?
           {:tyyppi {:koodiarvo "ammatillinentutkintoosittainen"}}))
-    (is (ammatillinen-tutkinto?
+    (is (ammatillisen-tutkinnon-suoritus?
           {:tyyppi {:koodiarvo "ammatillinentutkinto"}}))))
 
-(deftest test-has-one-or-more-ammatillinen-tutkinto?
+(deftest test-has-one-or-more-ammatillisen-tutkinnon-suoritus?
   (testing
     "Has one or more ammatillinen tutkinto in opiskeluoikeus suoritus types"
-    (is (not (has-one-or-more-ammatillinen-tutkinto?
+    (is (not (has-one-or-more-ammatillisen-tutkinnon-suoritus?
                {:suoritukset [{:tyyppi {:koodiarvo "valma"}}]})))
-    (is (has-one-or-more-ammatillinen-tutkinto?
+    (is (has-one-or-more-ammatillisen-tutkinnon-suoritus?
           {:suoritukset
            [{:tyyppi {:koodiarvo "ammatillinentutkinto"}}]}))
-    (is (has-one-or-more-ammatillinen-tutkinto?
+    (is (has-one-or-more-ammatillisen-tutkinnon-suoritus?
           {:suoritukset
            [{:tyyppi {:koodiarvo "nayttotutkintoonvalmistavakoulutus"}}
             {:tyyppi {:koodiarvo "ammatillinentutkintoosittainen"}}]}))
-    (is (not (has-one-or-more-ammatillinen-tutkinto?
+    (is (not (has-one-or-more-ammatillisen-tutkinnon-suoritus?
                {:suoritukset [{:tyyppi {:koodiarvo "valma"}}
                               {:tyyppi {:koodiarvo "telma"}}]})))))
 
@@ -200,7 +201,7 @@
 
 (deftest test-valid-herate-date?
   (testing "True if heratepvm is >= [rahoituskausi start year]-07-01"
-    (with-redefs [c/local-date-now (constantly (LocalDate/of 2023 6 22))]
+    (with-redefs [local-date-now (constantly (LocalDate/of 2023 6 22))]
       (is (true? (valid-herate-date? "2022-07-02")))
       (is (true? (valid-herate-date? "2022-07-01")))
       (is (not (true? (valid-herate-date? "2022-06-01"))))
@@ -208,7 +209,7 @@
       (is (not (true? (valid-herate-date? ""))))
       (is (not (true? (valid-herate-date? nil))))))
   (testing "Not true if heratepvm is < [rahoituskausi start year]-07-01"
-    (with-redefs [c/local-date-now (constantly (LocalDate/of 2023 7 22))]
+    (with-redefs [local-date-now (constantly (LocalDate/of 2023 7 22))]
       (is (not (true? (valid-herate-date? "2022-07-02"))))
       (is (not (true? (valid-herate-date? "2022-07-01")))))))
 

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -491,9 +491,9 @@
      :herate herate})
   false)
 
-(defn- mock-has-one-or-more-ammatillinen-tutkinto? [opiskeluoikeus]
+(defn- mock-has-one-or-more-ammatillisen-tutkinnon-suoritus? [opiskeluoikeus]
   (add-to-test-handleJaksoHerate-results
-    {:type "mock-has-one-or-more-ammatillinen-tutkinto?"
+    {:type "mock-has-one-or-more-ammatillisen-tutkinnon-suoritus?"
      :opiskeluoikeus opiskeluoikeus})
   true)
 
@@ -522,8 +522,8 @@
 
 (deftest test-handleJaksoHerate
   (testing "Varmista, että -handleJaksoHerate kutsuu funktioita oikein"
-    (with-redefs [c/has-one-or-more-ammatillinen-tutkinto?
-                  mock-has-one-or-more-ammatillinen-tutkinto?
+    (with-redefs [c/has-one-or-more-ammatillisen-tutkinnon-suoritus?
+                  mock-has-one-or-more-ammatillisen-tutkinnon-suoritus?
                   c/sisaltyy-toiseen-opiskeluoikeuteen?
                   mock-sisaltyy-toiseen-opiskeluoikeuteen?
                   c/get-koulutustoimija-oid mock-get-koulutustoimija-oid
@@ -562,7 +562,8 @@
                                :loppupvm "2021-12-15"
                                :hankkimistapa-id 12345
                                :keskeytymisajanjaksot []}}
-                     {:type "mock-has-one-or-more-ammatillinen-tutkinto?"
+                     {:type
+                      "mock-has-one-or-more-ammatillisen-tutkinnon-suoritus?"
                       :opiskeluoikeus
                       {:oid "123.456.789"
                        :koulutustoimija "mock-koulutustoimija-oid"}}


### PR DESCRIPTION
## Kuvaus muutoksista

Lisätty TUVA-opiskeluoikeuden tarkistus sekä AMIS- että TEP-herätteiden käsittelyyn.

:warning: Herätepalvelussa ei nykyisellään voida tarkistaa, onko HOKS TUVA-HOKSin kanssa rinnakkainen, jolloin ei myöskään kerätä palautetta. Tämä tarkitus täytyy tehdä joko kokonaan eHOKSin puolella, tai sitten tieto HOKSiin linkittyvästä TUVA-opiskeluoikeudesta on sisällytettävä Herätepalveluun lähetettävään herätetietueeseen.

https://jira.eduuni.fi/browse/OY-4444

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity
