### PR TITLE
EH-1700: Lambda työpaikkajaksojen kestojen uudelleenlaskentaan takautuvasti

### DIFF
--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -640,7 +640,9 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
         reservedConcurrentExecutions: 1,
         timeout: Duration.seconds(900),
         handler: "oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler::handleKestojenUudelleenlaskenta",
-        tracing: lambda.Tracing.ACTIVE
+        tracing: lambda.Tracing.ACTIVE,
+        logGroup: tepLogGroup,
+        vpc: vpc
     });
 
     new events.Rule(this, "KestojenUudelleenlaskentaScheduleRule", {

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -629,12 +629,11 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       this,
       "kestojenUudelleenlaskentaHandler",
       {
-        runtime: lambda.Runtime.JAVA_8_CORRETTO,
+        runtime: this.runtime,
         code: lambdaCode,
         environment: {
           ...this.envVars,
           jaksotunnus_table: jaksotunnusTable.tableName,
-          nippu_table: nippuTable.tableName,
           caller_id: `1.2.246.562.10.00000000001.${id}-kestojenUudelleenlaskentaHandler`,
         },
         memorySize: Token.asNumber(1024),
@@ -644,8 +643,12 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
         tracing: lambda.Tracing.ACTIVE
     });
 
+    new events.Rule(this, "KestojenUudelleenlaskentaScheduleRule", {
+      schedule: events.Schedule.expression("rate(15 minutes)"),
+      targets: [new targets.LambdaFunction(kestojenUudelleenlaskentaHandler)]
+    });
+
     jaksotunnusTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
-    nippuTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
 
     // Arkistointifunktiot
     const archiveJaksoTable = new lambda.Function(this, "archiveJaksoTable", {

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -624,6 +624,28 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
     });
 
     jaksotunnusTable.grantReadWriteData(dbChangerTep);
+    
+    const kestojenUudelleenlaskentaHandler = new lambda.Function(
+      this,
+      "kestojenUudelleenlaskentaHandler",
+      {
+        runtime: lambda.Runtime.JAVA_8_CORRETTO,
+        code: lambdaCode,
+        environment: {
+          ...this.envVars,
+          jaksotunnus_table: jaksotunnusTable.tableName,
+          nippu_table: nippuTable.tableName,
+          caller_id: `1.2.246.562.10.00000000001.${id}-kestojenUudelleenlaskentaHandler`,
+        },
+        memorySize: Token.asNumber(1024),
+        reservedConcurrentExecutions: 1,
+        timeout: Duration.seconds(900),
+        handler: "oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler::handleKestojenUudelleenlaskenta",
+        tracing: lambda.Tracing.ACTIVE
+    });
+
+    jaksotunnusTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
+    nippuTable.grantReadWriteData(kestojenUudelleenlaskentaHandler);
 
     // Arkistointifunktiot
     const archiveJaksoTable = new lambda.Function(this, "archiveJaksoTable", {
@@ -683,6 +705,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       dbChangerTep,
       archiveJaksoTable,
       archiveNippuTable,
+      kestojenUudelleenlaskentaHandler
     ].forEach(
         lambdaFunction => {
           lambdaFunction.addToRolePolicy(new iam.PolicyStatement({

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -1,8 +1,7 @@
 (ns oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler
-  "TODO"
+  "Handler työpaikkajaksojen kestojen uudelleenlaskentaa varten."
   (:require [clojure.tools.logging :as log]
             [environ.core :refer [env]]
-            [oph.heratepalvelu.common :as c]
             [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.log.caller-log :refer
              [log-caller-details-scheduled]]
@@ -15,55 +14,34 @@
              [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
               com.amazonaws.services.lambda.runtime.Context] void]])
 
-(def rahoituskausi {:alkupvm "2022-07-01" :loppupvm "2023-06-30"})
+(def alkupvm "2023-07-01")
 
-(defn scan-for-unhandled-nippus!
+(defn scan-for-jaksot-with-kesto!
+  "Hakee tietokannasta ne jaksot, jotka ovat päättyneet `alkupvm` jälkeen ja
+  joille on laskettu niputuksen yhteydessä kesto. Suodattaan jaksoja edelleen
+  siten, että jäljelle jääviltä jaksoilta löytyy vanhastaan laskettu kesto,
+  mutta ei uudella tavalla laskettua kestoa."
   [exclusive-start-key]
-  (let [resp (ddb/scan
-               {:filter-expression
-                (str
-                  "niputuspvm >= :rahoituskausi_alkupvm AND "
-                  "niputuspvm <= :rahoituskausi_loppupvm AND "
-                  "attribute_not_exists(keston_uudelleenlaskenta_suoritettu)")
-                :exclusive-start-key exclusive-start-key
-                :expr-attr-vals {":rahoituskausi_alkupvm"
-                                 [:s (:alkupvm rahoituskausi)]
-                                 ":rahoituskausi_loppupvm"
-                                 [:s (:loppupvm rahoituskausi)]}}
-               (:nippu-table env))]
-    (log/info "Haettiin onnistuneesti " (count (:items resp)) " nippua")
-    resp))
-
-(defn query-jaksot-with-kesto!
-  "Hakee tietokannasta ne jaksot, jotka kuuluvat parametrina annettuun nippuun.
-  Suodattaan jaksoja edelleen siten, että jäljelle jääviltä jaksoilta löytyy
-  vanhastaan laskettu kesto, mutta ei uudella tavalla laskettua kestoa."
-  [nippu]
-  (ddb/query-items
-    {:ohjaaja_ytunnus_kj_tutkinto
-     [:eq [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]]
-     :niputuspvm [:eq [:s (:niputuspvm nippu)]]}
-    {:index "niputusIndex"
-     :filter-expression
-     "attribute_exists(kesto) AND attribute_not_exists(kesto_vanha)"}
-    (:jaksotunnus-table env)))
+  (ddb/scan {:filter-expression   (str "jakso_loppupvm >= :alkupvm AND "
+                                       "attribute_exists(kesto) AND "
+                                       "attribute_not_exists(kesto_vanha)")
+             :exclusive-start-key exclusive-start-key
+             :expr-attr-vals      {":alkupvm" [:s alkupvm]}}
+            (:jaksotunnus-table env)))
 
 (defn -handleKestojenUudelleenlaskenta
   [_ event ^com.amazonaws.services.lambda.runtime.Context context]
   (log-caller-details-scheduled "handleKestojenUudelleenlaskenta" event context)
-  (loop [niput (scan-for-unhandled-nippus! nil)]
-    (doseq [nippu (:items niput)]
-      (let [jaksot (query-jaksot-with-kesto! nippu)
-            kestot (nh/jaksojen-kestot! jaksot)]
-        (log/info "Jaksot: " jaksot ", Kestot: " kestot)
-        (doseq [jakso jaksot]
+  (loop [resp (scan-for-jaksot-with-kesto! nil)]
+    (let [jaksot (:items resp)
+          kestot (nh/jaksojen-kestot! jaksot)]
+      (doseq [jakso jaksot]
+        (if-let [new-kesto (get kestot (nh/ids jakso))]
           (tc/update-jakso jakso
-                           {:kesto [:n (get kestot
-                                            (:hankkimistapa_id jakso)
-                                            0)]
-                            :kesto_vanha [:n (:kesto jakso)]})))
-      (tc/update-nippu nippu {:keston_uudelleenlaskenta_suoritettu
-                              [:s (str (c/local-date-now))]}))
+                           {:kesto       [:n new-kesto]
+                            :kesto_vanha [:n (:kesto jakso)]})
+          (log/warn "Couldn't calculate kesto for jakso with ids "
+                    (nh/ids jakso)))))
     (when (and (< 30000 (.getRemainingTimeInMillis context))
-               (:last-evaluated-key niput))
-      (recur (scan-for-unhandled-nippus! (:last-evaluated-key niput))))))
+               (:last-evaluated-key resp))
+      (recur (scan-for-jaksot-with-kesto! (:last-evaluated-key resp))))))

--- a/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/kestojenUudelleenlaskentaHandler.clj
@@ -1,0 +1,69 @@
+(ns oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler
+  "TODO"
+  (:require [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
+            [oph.heratepalvelu.common :as c]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
+            [oph.heratepalvelu.log.caller-log :refer
+             [log-caller-details-scheduled]]
+            [oph.heratepalvelu.tep.niputusHandler :as nh]
+            [oph.heratepalvelu.tep.tepCommon :as tc]))
+
+(gen-class :name "oph.heratepalvelu.tep.kestojenUudelleenlaskentaHandler"
+           :methods
+           [[^:static handleKestojenUudelleenlaskenta
+             [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+              com.amazonaws.services.lambda.runtime.Context] void]])
+
+(def rahoituskausi {:alkupvm "2022-07-01" :loppupvm "2023-06-30"})
+
+(defn scan-for-unhandled-nippus!
+  [exclusive-start-key]
+  (let [resp (ddb/scan
+               {:filter-expression
+                (str
+                  "niputuspvm >= :rahoituskausi_alkupvm AND "
+                  "niputuspvm <= :rahoituskausi_loppupvm AND "
+                  "attribute_not_exists(keston_uudelleenlaskenta_suoritettu)")
+                :exclusive-start-key exclusive-start-key
+                :expr-attr-vals {":rahoituskausi_alkupvm"
+                                 [:s (:alkupvm rahoituskausi)]
+                                 ":rahoituskausi_loppupvm"
+                                 [:s (:loppupvm rahoituskausi)]}}
+               (:nippu-table env))]
+    (log/info "Haettiin onnistuneesti " (count (:items resp)) " nippua")
+    resp))
+
+(defn query-jaksot-with-kesto!
+  "Hakee tietokannasta ne jaksot, jotka kuuluvat parametrina annettuun nippuun.
+  Suodattaan jaksoja edelleen siten, että jäljelle jääviltä jaksoilta löytyy
+  vanhastaan laskettu kesto, mutta ei uudella tavalla laskettua kestoa."
+  [nippu]
+  (ddb/query-items
+    {:ohjaaja_ytunnus_kj_tutkinto
+     [:eq [:s (:ohjaaja_ytunnus_kj_tutkinto nippu)]]
+     :niputuspvm [:eq [:s (:niputuspvm nippu)]]}
+    {:index "niputusIndex"
+     :filter-expression
+     "attribute_exists(kesto) AND attribute_not_exists(kesto_vanha)"}
+    (:jaksotunnus-table env)))
+
+(defn -handleKestojenUudelleenlaskenta
+  [_ event ^com.amazonaws.services.lambda.runtime.Context context]
+  (log-caller-details-scheduled "handleKestojenUudelleenlaskenta" event context)
+  (loop [niput (scan-for-unhandled-nippus! nil)]
+    (doseq [nippu (:items niput)]
+      (let [jaksot (query-jaksot-with-kesto! nippu)
+            kestot (nh/jaksojen-kestot! jaksot)]
+        (log/info "Jaksot: " jaksot ", Kestot: " kestot)
+        (doseq [jakso jaksot]
+          (tc/update-jakso jakso
+                           {:kesto [:n (get kestot
+                                            (:hankkimistapa_id jakso)
+                                            0)]
+                            :kesto_vanha [:n (:kesto jakso)]})))
+      (tc/update-nippu nippu {:keston_uudelleenlaskenta_suoritettu
+                              [:s (str (c/local-date-now))]}))
+    (when (and (< 30000 (.getRemainingTimeInMillis context))
+               (:last-evaluated-key niput))
+      (recur (scan-for-unhandled-nippus! (:last-evaluated-key niput))))))

--- a/src/oph/heratepalvelu/tep/niputusHandler.clj
+++ b/src/oph/heratepalvelu/tep/niputusHandler.clj
@@ -253,8 +253,8 @@
   `oppijan-jaksojen-kestot`-funktion tekemää kestojen laskemista.
 
   Palauttaa hashmapin, joka sisältää `jaksot` listan jaksoille lasketut kestot.
-  Hashmapin avaimina jaksojen id:t (osaamisenhankkimistapojen) ja arvoina kestot
-  kokonaislukuina."
+  Hashmapin avaimina jaksojen id:t (HOKS id + yksiloiva tunniste) ja arvoina
+  kestot kokonaislukuina."
   [jaksot]
   (->> (group-by :oppija_oid jaksot) ; Ryhmitellään jaksot oppijan perusteella
        vals


### PR DESCRIPTION
## Kuvaus muutoksista

~~Minimaaliset päivitykset aiempaan kestonlaskenta-lambdan toteutukseen. Vanhan toteutuksen PR: https://github.com/Opetushallitus/heratepalvelu/pull/217~~

~~https://jira.eduuni.fi/browse/EH-1549~~

Tiketissä [EH-1699](https://jira.eduuni.fi/browse/EH-1699) korjattiin kestonlaskentalogiikka käyttämään hankkimistapa id:n sijasta HOKS id:tä ja yksilöivää tunnistetta. Tässä on laadittu lambda, joka suorittaa kestojen uudelleenlaskennan takautuvasti edellisen ja meneillään olevan rahoituskauden jaksoille.

https://jira.eduuni.fi/browse/EH-1700

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [x] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [x] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [x] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [x] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity