### PR TITLE
Always include `voimassa_loppupvm` in nippulinkki PATCH requests

### DIFF
--- a/src/oph/heratepalvelu/tep/StatusHandler.clj
+++ b/src/oph/heratepalvelu/tep/StatusHandler.clj
@@ -59,7 +59,7 @@
                   (:kyselylinkki nippu)
                   (if (and new-loppupvm (= tila (:success c/kasittelytilat)))
                     {:tila tila :voimassa_loppupvm new-loppupvm}
-                    {:tila tila})))
+                    {:tila tila :voimassa_loppupvm (:voimassaloppupvm nippu)})))
               (log/info "Päivitetään tietokantaan tila" tila
                         "loppupvm" new-loppupvm)
               (tc/update-nippu

--- a/src/oph/heratepalvelu/tep/emailHandler.clj
+++ b/src/oph/heratepalvelu/tep/emailHandler.clj
@@ -42,8 +42,10 @@
                               (:email-mismatch c/kasittelytilat))]
           (tc/update-nippu nippu {:kasittelytila [:s kasittelytila]}))
         (when (bad-phone? nippu)
-          (arvo/patch-nippulinkki (:kyselylinkki nippu)
-                                  {:tila (:ei-yhteystietoja c/kasittelytilat)}))
+          (arvo/patch-nippulinkki
+            (:kyselylinkki nippu)
+            {:tila (:ei-yhteystietoja c/kasittelytilat)
+             :voimassa_loppupvm (:voimassaloppupvm nippu)}))
         nil))))
 
 (defn do-nippu-query

--- a/test/oph/heratepalvelu/integration_tests/tep/StatusHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/StatusHandler_i_test.clj
@@ -170,13 +170,15 @@
     :options {:as :json
               :basic-auth ["arvo-user" "arvo-pwd"]
               :content-type "application/json"
-              :body "{\"tila\":\"lahetetty\"}"}}
+              :body (str "{\"tila\":\"lahetetty\","
+                         "\"voimassa_loppupvm\":\"2022-02-28\"}")}}
    {:method :patch
     :url (str (:arvo-url mock-env) "tyoelamapalaute/v1/nippu/asdf_b")
     :options {:as :json
               :basic-auth ["arvo-user" "arvo-pwd"]
               :content-type "application/json"
-              :body "{\"tila\":\"lahetys_epaonnistunut\"}"}}])
+              :body (str "{\"tila\":\"lahetys_epaonnistunut\","
+                         "\"voimassa_loppupvm\":\"2022-02-28\"}")}}])
 
 (deftest test-StatusHandler-integration
   (testing "StatusHandler integraatiotesti"

--- a/test/oph/heratepalvelu/integration_tests/tep/emailHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/emailHandler_i_test.clj
@@ -171,7 +171,8 @@
                              {:basic-auth ["arvo-user" "arvo-pwd"]
                               :content-type "application/json"
                               :body
-                              "{\"tila\":\"ei_kelvollisia_yhteystietoja\"}"
+                              (str "{\"tila\":\"ei_kelvollisia_yhteystietoja\","
+                                   "\"voimassa_loppupvm\":\"2022-03-01\"}")
                               :as :json}}
                             {:method :get
                              :url "https://oph-organisaatio.com/test-laitos"

--- a/test/oph/heratepalvelu/integration_tests/tep/tepSmsHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/tepSmsHandler_i_test.clj
@@ -204,7 +204,8 @@
     :url (str (:arvo-url mock-env) "tyoelamapalaute/v1/nippu/3")
     :options {:basic-auth   ["arvo-user" "arvo-pwd"]
               :content-type "application/json"
-              :body         "{\"tila\":\"ei_kelvollisia_yhteystietoja\"}"
+              :body         (str "{\"tila\":\"ei_kelvollisia_yhteystietoja\","
+                                 "\"voimassa_loppupvm\":\"2022-02-28\"}")
               :as           :json}}
    {:method :get
     :url "testilaitos"
@@ -216,7 +217,8 @@
     :url (str (:arvo-url mock-env) "tyoelamapalaute/v1/nippu/5")
     :options {:basic-auth   ["arvo-user" "arvo-pwd"]
               :content-type "application/json"
-              :body         "{\"tila\":\"ei_kelvollisia_yhteystietoja\"}"
+              :body         (str "{\"tila\":\"ei_kelvollisia_yhteystietoja\","
+                                 "\"voimassa_loppupvm\":\"2022-02-28\"}")
               :as           :json}}])
 
 (deftest test-tepSmsHandler-integration

--- a/test/oph/heratepalvelu/tep/StatusHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/StatusHandler_test.clj
@@ -115,7 +115,8 @@
                      {:type "mock-get-email-status" :id 3}
                      {:type "mock-patch-nippulinkki"
                       :kyselylinkki "kysely.linkki/asdf"
-                      :data {:tila (:failed c/kasittelytilat)}}
+                      :data {:tila (:failed c/kasittelytilat)
+                             :voimassa_loppupvm "2021-11-11"}}
                      {:type "mock-update-nippu"
                       :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id-3"
                               :niputuspvm "2021-12-15"

--- a/test/oph/heratepalvelu/tep/emailHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/emailHandler_test.clj
@@ -43,10 +43,12 @@
                   mock-lahetysosoite-update-nippu]
       (let [nippu {:ohjaaja_ytunnus_kj_tutkinto "test-nippu-id"
                    :niputuspvm "2021-10-10"
+                   :voimassaloppupvm "2021-11-10"
                    :sms_kasittelytila (:success c/kasittelytilat)
                    :kyselylinkki "kysely.linkki/123"}
             nippu-bad-phone {:ohjaaja_ytunnus_kj_tutkinto "test-bad-phone-id"
                              :niputuspvm "2021-10-10"
+                             :voimassaloppupvm "2021-11-10"
                              :kyselylinkki "kysely.linkki/1234"
                              :sms_kasittelytila
                              (:phone-mismatch c/kasittelytilat)}
@@ -75,7 +77,8 @@
                 {:kasittelytila [:s (:email-mismatch c/kasittelytilat)]}}))
         (is (= @mock-patch-nippulinkki-result
                {:kyselylinkki "kysely.linkki/1234"
-                :data {:tila (:ei-yhteystietoja c/kasittelytilat)}}))
+                :data {:tila (:ei-yhteystietoja c/kasittelytilat)
+                       :voimassa_loppupvm "2021-11-10"}}))
         (is (true? (tu/logs-contain?
                      {:level :warn
                       :message (str "Ei yksiselitteistä ohjaajan sähköpostia  "

--- a/test/oph/heratepalvelu/tep/tepSmsHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/tepSmsHandler_test.clj
@@ -90,6 +90,7 @@
                              {:ohjaaja_puhelinnumero "+358407654321"}]
             nippu-base {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                         :niputuspvm "2021-12-15"
+                        :voimassaloppupvm "2022-01-15"
                         :kyselylinkki "kysely.linkki/123"}
             nippu-good-email
             (assoc nippu-base :kasittelytila (:ei-lahetetty c/kasittelytilat))
@@ -107,6 +108,7 @@
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:ei-lahetetty c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
@@ -119,6 +121,7 @@
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:email-mismatch c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
@@ -126,13 +129,15 @@
                            :lahetettynumeroon [:s "1234"]}}
                 {:type "mock-ohjaaja-puhnro-patch-nippulinkki"
                  :kyselylinkki "kysely.linkki/123"
-                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)}}]))
+                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)
+                        :voimassa_loppupvm "2022-01-15"}}]))
         (reset-test-ohjaaja-puhnro-results)
         (is (nil? (sh/ohjaaja-puhnro nippu-no-email jaksot-one-invalid-number)))
         (is (= (vec (reverse @test-ohjaaja-puhnro-results))
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:no-email c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
@@ -140,13 +145,15 @@
                            :lahetettynumeroon [:s "1234"]}}
                 {:type "mock-ohjaaja-puhnro-patch-nippulinkki"
                  :kyselylinkki "kysely.linkki/123"
-                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)}}]))
+                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)
+                        :voimassa_loppupvm "2022-01-15"}}]))
         (reset-test-ohjaaja-puhnro-results)
         (is (nil? (sh/ohjaaja-puhnro nippu-good-email jaksot-no-number)))
         (is (= (vec (reverse @test-ohjaaja-puhnro-results))
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:ei-lahetetty c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
@@ -157,26 +164,30 @@
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:email-mismatch c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
                            [:s (:phone-mismatch c/kasittelytilat)]}}
                 {:type "mock-ohjaaja-puhnro-patch-nippulinkki"
                  :kyselylinkki "kysely.linkki/123"
-                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)}}]))
+                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)
+                        :voimassa_loppupvm "2022-01-15"}}]))
         (reset-test-ohjaaja-puhnro-results)
         (is (nil? (sh/ohjaaja-puhnro nippu-no-email jaksot-no-number)))
         (is (= (vec (reverse @test-ohjaaja-puhnro-results))
                [{:type "mock-ohjaaja-puhnro-update-nippu"
                  :nippu {:ohjaaja_ytunnus_kj_tutkinto "test-id"
                          :niputuspvm "2021-12-15"
+                         :voimassaloppupvm "2022-01-15"
                          :kasittelytila (:no-email c/kasittelytilat)
                          :kyselylinkki "kysely.linkki/123"}
                  :updates {:sms_kasittelytila
                            [:s (:no-phone c/kasittelytilat)]}}
                 {:type "mock-ohjaaja-puhnro-patch-nippulinkki"
                  :kyselylinkki "kysely.linkki/123"
-                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)}}]))))))
+                 :data {:tila (:ei-yhteystietoja c/kasittelytilat)
+                        :voimassa_loppupvm "2022-01-15"}}]))))))
 
 (def test-query-lahetettavat-results (atom {}))
 


### PR DESCRIPTION
## Kuvaus muutoksista

`voimassa_loppupvm` kenttä on Arvossa nykyään pakollinen nippulinkkejä päivittävissä PATCH requesteissa. Tämän muutoksen myötä `voimassa_loppupvm` sisällytetään PATCH-requesteihin aina, riippumatta onko kyseistä tietoa päivitetty vai ei.

https://jira.eduuni.fi/browse/EH-1558

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity