### PR TITLE
Add metric filters to lambda log groups

### DIFF
--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -695,6 +695,7 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
           resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
           actions: ['ssm:GetParameter']
         }));
+        this.createMetricFilters(lambdaFunction);
       }
     );
   }

--- a/cdk/lib/heratepalvelu.ts
+++ b/cdk/lib/heratepalvelu.ts
@@ -1,5 +1,6 @@
 import { Stack, App, StackProps, Tags } from 'aws-cdk-lib';
 import lambda = require("aws-cdk-lib/aws-lambda");
+import { FilterPattern, MetricFilter } from 'aws-cdk-lib/aws-logs';
 import ssm = require("aws-cdk-lib/aws-ssm");
 
 export type EnvVars = {
@@ -56,6 +57,19 @@ export class HeratepalveluStack extends Stack {
     };
 
     this.runtime = lambda.Runtime.JAVA_11;
+  }
+
+  createMetricFilters = (lambdaFunction: lambda.Function) => {
+      const metricNamespace = 'OpintopolkuLogMetrics';
+      const logGroup = lambdaFunction.logGroup;
+      const functionName = lambdaFunction.node.id;
+      new MetricFilter(this, `${functionName}LogErrors`, {
+        logGroup,
+        metricNamespace: metricNamespace,
+        metricName: `${this.envName}/heratepalvelu/${functionName}/errors`,
+        filterPattern: FilterPattern.literal('ERROR'),
+        metricValue: "1"
+      });
   }
 
   getParameterFromSsm = (parameterName: string): string => {

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -573,6 +573,7 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
             resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
             actions: ['ssm:GetParameter']
           }));
+          this.createMetricFilters(lambdaFunction);
         }
     );
   }

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -120,11 +120,14 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       tpkArvoCallHandler,
       //archiveTpkNippuTable,
     ].forEach(
-      lambdaFunction => lambdaFunction.addToRolePolicy(new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
-        actions: ["ssm:GetParameter"],
-      }))
+      lambdaFunction => {
+        lambdaFunction.addToRolePolicy(new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
+          actions: ["ssm:GetParameter"],
+        }));
+        this.createMetricFilters(lambdaFunction);
+      }
     );
   }
 }


### PR DESCRIPTION
## Kuvaus muutoksista

Lisätään metric filterit pitämään kirjaa ERROR-lokitusten lukumääristä lokeissa. Vastaavanlaisia metric filtereitä löytyy jo muiden Opintopolun palveluiden lokiryhmistä, mutta nämä puuttuvat kaikista Herätepalveun lambdojen lokiryhmistä. Näiden metric filtereiden lisääminen on edellytys sille, että voidaan nostaa näitä ERROR-lukumäärämetriikoita näkymiin dashboardille, ja tarvittaessa myös nostamaan hälyjä niiden perusteella.

https://jira.eduuni.fi/browse/EH-1471

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
  - [ ] Yli jääneet kehityskohteet on tiketöity