### PR TITLE
EH-1563: Korjaa herätteiden uudelleenlähetyksen logiikka

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISCommon.clj
+++ b/src/oph/heratepalvelu/amis/AMISCommon.clj
@@ -141,7 +141,6 @@
                     uuid)
           (save-herate-ddb! db-data-cond-values herate-source
                             oppija koulutustoimija laskentakausi kyselytyyppi)
-          (update-herate-ehoks! (:ehoks-id herate) kyselytyyppi)
           (when (c/has-nayttotutkintoonvalmistavakoulutus? opiskeluoikeus)
             (log/info
               {:nayttotutkinto        true

--- a/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISehoksTimedOperationsHandler.clj
@@ -27,7 +27,9 @@
             "aloittaneille tai suorituksia saaneille,"
             "joilla ei ole vielä kyselylinkkiä")
   (let [resp (ehoks/send-kasittelemattomat-heratteet!
-               "2021-07-01" (str (c/local-date-now)) 1000)]
+               (str (c/current-rahoituskausi-alkupvm))
+               (str (c/local-date-now))
+               1000)]
     (log/info "Lähetetty" (:data (:body resp)) "viestiä")))
 
 (defn delete-oppija-contact!

--- a/src/oph/heratepalvelu/amis/AMISherateHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateHandler.clj
@@ -52,7 +52,8 @@
                   (:sisältyyOpiskeluoikeuteen opiskeluoikeus) ":" summary)
 
         :else (ac/check-and-save-herate! herate opiskeluoikeus koulutustoimija
-                                         (:ehoks herate-sources))))
+                                         (:ehoks herate-sources)))
+      (ac/update-herate-ehoks! (:ehoks-id herate) (:kyselytyyppi herate)))
     (catch JsonParseException e
       (log/error e "Virhe viestin lukemisessa:" (.getBody msg) "\n" e))
     (catch ExceptionInfo e

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -115,8 +115,11 @@
                        hoks (get-kysely-type opiskeluoikeus) vahvistus-pvm)]
           (if-not (:osaamisen-hankkimisen-tarve hoks)
             (log/info "Ei osaamisen hankkimisen tarvetta hoksissa" (:id hoks))
-            (ac/check-and-save-herate! herate opiskeluoikeus koulutustoimija
-                                       (:koski herate-sources))))
+            (do
+              (ac/check-and-save-herate! herate opiskeluoikeus koulutustoimija
+                                         (:koski herate-sources))
+              (ac/update-herate-ehoks! (:ehoks-id herate)
+                                       (:kyselytyyppi herate)))))
         (catch ExceptionInfo e
           (if (= 404 (:status (ex-data e)))
             (log/info "Opiskeluoikeudella" (:oid opiskeluoikeus)

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -291,19 +291,24 @@
       (ddb/delete-item {:toimija_oppija [:s (str koulutustoimija "/" oppija)]
                         :tyyppi_kausi   [:s (str tyyppi "/" laskentakausi)]}))))
 
+(defn current-rahoituskausi-alkupvm
+  ^LocalDate []
+  (let [current-year (.getYear (local-date-now))
+        ^int rahoituskausi-year (if (< (.getMonthValue (local-date-now)) 7)
+                                  (dec current-year)
+                                  current-year)]
+    (LocalDate/of
+      rahoituskausi-year
+      7
+      1)))
+
 (defn valid-herate-date?
   "onko herätteen päivämäärä aikaisintaan kuluvan rahoituskauden alkupvm
   (1.7.)?"
   [heratepvm]
   (try
-    (let [current-year (.getYear (local-date-now))
-          rahoituskausi-alkuvuosi (if (< (.getMonthValue (local-date-now)) 7)
-                                    (dec current-year)
-                                    current-year)
-          rahoituskausi-alkupvm (LocalDate/of
-                                  ^long rahoituskausi-alkuvuosi 7 1)]
-      (not (.isAfter rahoituskausi-alkupvm
-                     (LocalDate/parse (or heratepvm "")))))
+    (not (.isAfter (current-rahoituskausi-alkupvm)
+                   (LocalDate/parse (or heratepvm ""))))
     (catch DateTimeParseException e
       (log/warn "Bad date" heratepvm)
       false)))

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -18,7 +18,9 @@
   [_ _ _]
   (log/info "Käynnistetään jaksojen lähetys")
   (let [resp (ehoks/get-paattyneet-tyoelamajaksot
-               "2021-07-01" (str (c/local-date-now)) 1500)]
+               (str (c/current-rahoituskausi-alkupvm))
+               (str (c/local-date-now))
+               1500)]
     (log/info "Lähetetty" (:data (:body resp)) "viestiä"))
 
   (log/info "Käynnistetään työpaikkaohjaajan yhteystietojen poisto")

--- a/test/oph/heratepalvelu/amis/AMISCommon_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISCommon_test.clj
@@ -61,14 +61,6 @@
                         :ehoks-id ehoks-id
                         :data data}))
 
-(defn- mock-patch-amis-aloitusherate-kasitelty [ehoks-id]
-  (add-to-test-results {:type "mock-patch-amis-aloitusherate-kasitelty"
-                        :ehoks-id ehoks-id}))
-
-(defn- mock-patch-amis-paattoherate-kasitelty [ehoks-id]
-  (add-to-test-results {:type "mock-patch-amis-paattoherate-kasitelty"
-                        :ehoks-id ehoks-id}))
-
 (defn- mock-has-nayttotutkintoonvalmistavakoulutus? [opiskeluoikeus]
   (add-to-test-results {:type "mock-has-nayttotutkintoonvalmistavakoulutus?"
                         :opiskeluoikeus opiskeluoikeus})
@@ -109,11 +101,7 @@
        oph.heratepalvelu.external.arvo/get-osaamisalat mock-get-osaamisalat
        oph.heratepalvelu.external.arvo/get-toimipiste mock-get-toimipiste
        oph.heratepalvelu.external.ehoks/add-kyselytunnus-to-hoks
-       mock-add-kyselytunnus-to-hoks
-       oph.heratepalvelu.external.ehoks/patch-amis-aloitusherate-kasitelty
-       mock-patch-amis-aloitusherate-kasitelty
-       oph.heratepalvelu.external.ehoks/patch-amis-paattoherate-kasitelty
-       mock-patch-amis-paattoherate-kasitelty]
+       mock-add-kyselytunnus-to-hoks]
       (let [herate-1 {:kyselytyyppi "aloittaneet"
                       :alkupvm "2021-12-15"
                       :oppija-oid "34.56.78"
@@ -201,8 +189,6 @@
                              :herate-source [:s (:ehoks c/herate-sources)]}
                       :options
                       {:cond-expr "attribute_not_exists(kyselylinkki)"}}
-                     {:type "mock-patch-amis-aloitusherate-kasitelty"
-                      :ehoks-id 98}
                      {:type "mock-has-nayttotutkintoonvalmistavakoulutus?"
                       :opiskeluoikeus
                       {:oppilaitos {:oid "test-laitos-id"}
@@ -267,8 +253,6 @@
                        :expr-attr-names {"#source" "herate-source"}
                        :expr-attr-vals
                        {":koski" [:s (:koski c/herate-sources)]}}}
-                     {:type "mock-patch-amis-paattoherate-kasitelty"
-                      :ehoks-id 98}
                      {:type "mock-has-nayttotutkintoonvalmistavakoulutus?"
                       :opiskeluoikeus
                       {:oppilaitos {:oid "test-laitos-id"}
@@ -331,8 +315,6 @@
                                 :puhelinnumero [:s "1234567"]},
                       :options {:cond-expr
                                 "attribute_not_exists(kyselylinkki)"}}
-                     {:type "mock-patch-amis-paattoherate-kasitelty",
-                      :ehoks-id 98}
                      {:type "mock-has-nayttotutkintoonvalmistavakoulutus?",
                       :opiskeluoikeus {:oppilaitos  {:oid "test-laitos-id"},
                                        :oid         "123.456.789",
@@ -391,8 +373,6 @@
                              :herate-source [:s (:ehoks c/herate-sources)]}
                       :options
                       {:cond-expr "attribute_not_exists(kyselylinkki)"}}
-                     {:type "mock-patch-amis-paattoherate-kasitelty"
-                      :ehoks-id 98}
                      {:type "mock-has-nayttotutkintoonvalmistavakoulutus?"
                       :opiskeluoikeus
                       {:oppilaitos {:oid "test-laitos-id"}

--- a/test/oph/heratepalvelu/common_test.clj
+++ b/test/oph/heratepalvelu/common_test.clj
@@ -198,6 +198,15 @@
     (is (str/starts-with? (create-nipputunniste "árvíztűrő tükörfúrógép")
                           "arvizturo_tukorfurogep"))))
 
+(deftest test-current-rahoituskausi-alkupvm
+  (testing "Is 1st of July of the current rahoituskausi"
+    (with-redefs [c/local-date-now #(LocalDate/of 2023 6 22)]
+      (is (= "2022-07-01" (str (current-rahoituskausi-alkupvm)))))
+    (with-redefs [c/local-date-now #(LocalDate/of 2023 7 22)]
+      (is (= "2023-07-01" (str (current-rahoituskausi-alkupvm)))))
+    (with-redefs [c/local-date-now #(LocalDate/of 2024 1 10)]
+      (is (= "2023-07-01" (str (current-rahoituskausi-alkupvm)))))))
+
 (deftest test-valid-herate-date?
   (testing "True if heratepvm is >= [rahoituskausi start year]-07-01"
     (with-redefs [c/local-date-now (constantly (LocalDate/of 2023 6 22))]


### PR DESCRIPTION
- käytä kuluvan rahoituskauden alkupäivää uudelleenlähetyspyynnöissä
- tallenna herätteen käsittelytila eHOKSiin myös niissä tapauksissa, kun herätettä ei tallenneta Herätepalveluun