### PR TITLE
EH-1578: Automatisoidaan TPK-kyselylinkkien muodostusajot

### DIFF
--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -81,13 +81,13 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
 
     new events.Rule(this, "TPKNiputusHandlerDefaultScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 0-5 * JUN,DEC MON,THU *)`
+          `cron(5,25,45 0-5 ? JUN,DEC MON,THU *)`
       ),
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
     new events.Rule(this, "TPKNiputusHandlerJanuaryFirstScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 0-5 1 JAN * *)`
+          `cron(5,25,45 0-5 1 JAN ? *)`
       ),
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
@@ -110,13 +110,13 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
 
     new events.Rule(this, "TPKArvoCallHandlerDefaultScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 6-18 * JUN,DEC MON,THU *)`
+          `cron(5,25,45 6-18 ? JUN,DEC MON,THU *)`
       ),
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
     new events.Rule(this, "TPKArvoCallHandlerJanuaryFirstScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 6-18 1 JAN * *))`
+          `cron(5,25,45 6-18 1 JAN ? *))`
       ),
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -1,5 +1,7 @@
 import { App, Duration, Token, StackProps } from 'aws-cdk-lib';
 import dynamodb = require("aws-cdk-lib/aws-dynamodb");
+import events = require("aws-cdk-lib/aws-events");
+import targets = require("aws-cdk-lib/aws-events-targets");
 import lambda = require("aws-cdk-lib/aws-lambda");
 import s3assets = require("aws-cdk-lib/aws-s3-assets");
 import iam = require("aws-cdk-lib/aws-iam");
@@ -77,6 +79,19 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
     tepJaksotunnusTable.grantReadWriteData(tpkNiputusHandler);
     tpkNippuTable.grantReadWriteData(tpkNiputusHandler);
 
+    new events.Rule(this, "TPKNiputusHandlerDefaultScheduleRule", {
+      schedule: events.Schedule.expression(
+          `cron(5,25,45 0-5 * JUN,DEC MON,THU *)`
+      ),
+      targets: [new targets.LambdaFunction(tpkNiputusHandler)]
+    });
+    new events.Rule(this, "TPKNiputusHandlerJanuaryFirstScheduleRule", {
+      schedule: events.Schedule.expression(
+          `cron(5,25,45 0-5 1 JAN * *)`
+      ),
+      targets: [new targets.LambdaFunction(tpkNiputusHandler)]
+    });
+
     const tpkArvoCallHandler = new lambda.Function(this, "TPKArvoCallHandler", {
       runtime: this.runtime,
       code: lambdaCode,
@@ -93,27 +108,40 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
 
     tpkNippuTable.grantReadWriteData(tpkArvoCallHandler);
 
- /*   const archiveTpkNippuTable = new lambda.Function(
-      this,
-      "archiveTpkNippuTable",
-      {
-        runtime: this.runtime,
-        code: lambdaCode,
-        environment: {
-          ...this.envVars,
-          tpk_nippu_table: tpkNippuTable.tableName,
-          archive_table_2021_fall: tpkNippuArchive2021FallTable.tableName,
-          caller_id: `1.2.246.562.10.00000000001.${id}-archiveTpkNippuTable`,
-        },
-        memorySize: Token.asNumber(1024),
-        timeout: Duration.seconds(900),
-        handler: "oph.heratepalvelu.tpk.archiveTpkNippuTable::archiveTpkNippuTable",
-        tracing: lambda.Tracing.ACTIVE,
-      }
-    );
+    new events.Rule(this, "TPKArvoCallHandlerDefaultScheduleRule", {
+      schedule: events.Schedule.expression(
+          `cron(5,25,45 6-18 * JUN,DEC MON,THU *)`
+      ),
+      targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
+    });
+    new events.Rule(this, "TPKArvoCallHandlerJanuaryFirstScheduleRule", {
+      schedule: events.Schedule.expression(
+          `cron(5,25,45 6-18 1 JAN * *))`
+      ),
+      targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
+    });
 
-    tpkNippuTable.grantReadWriteData(archiveTpkNippuTable);
-    tpkNippuArchive2021FallTable.grantReadWriteData(archiveTpkNippuTable);*/
+    /*   const archiveTpkNippuTable = new lambda.Function(
+         this,
+         "archiveTpkNippuTable",
+         {
+           runtime: this.runtime,
+           code: lambdaCode,
+           environment: {
+             ...this.envVars,
+             tpk_nippu_table: tpkNippuTable.tableName,
+             archive_table_2021_fall: tpkNippuArchive2021FallTable.tableName,
+             caller_id: `1.2.246.562.10.00000000001.${id}-archiveTpkNippuTable`,
+           },
+           memorySize: Token.asNumber(1024),
+           timeout: Duration.seconds(900),
+           handler: "oph.heratepalvelu.tpk.archiveTpkNippuTable::archiveTpkNippuTable",
+           tracing: lambda.Tracing.ACTIVE,
+         }
+       );
+
+       tpkNippuTable.grantReadWriteData(archiveTpkNippuTable);
+       tpkNippuArchive2021FallTable.grantReadWriteData(archiveTpkNippuTable);*/
 
     [
       tpkNiputusHandler,

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -83,14 +83,14 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       schedule: events.Schedule.expression(
           `cron(5,25,45 0-5 ? JUN,DEC MON,THU *)`
       ),
-      enabled: false,
+      enabled: true,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
     new events.Rule(this, "TPKNiputusHandlerFinalizingScheduleRule", {
       schedule: events.Schedule.expression(
           `cron(5,25,45 0-5 1 JAN,JUL ? *)`
       ),
-      enabled: false,
+      enabled: true,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
 
@@ -114,14 +114,14 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       schedule: events.Schedule.expression(
           `cron(5,25,45 6-18 ? JUN,DEC MON,THU *)`
       ),
-      enabled: false,
+      enabled: true,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
     new events.Rule(this, "TPKArvoCallHandlerFinalizingScheduleRule", {
       schedule: events.Schedule.expression(
           `cron(5,25,45 6-18 1 JAN,JUL ? *)`
       ),
-      enabled: false,
+      enabled: true,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
 

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -83,12 +83,14 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       schedule: events.Schedule.expression(
           `cron(5,25,45 0-5 ? JUN,DEC MON,THU *)`
       ),
+      enabled: false,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
     new events.Rule(this, "TPKNiputusHandlerJanuaryFirstScheduleRule", {
       schedule: events.Schedule.expression(
           `cron(5,25,45 0-5 1 JAN ? *)`
       ),
+      enabled: false,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
 
@@ -112,12 +114,14 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       schedule: events.Schedule.expression(
           `cron(5,25,45 6-18 ? JUN,DEC MON,THU *)`
       ),
+      enabled: false,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
     new events.Rule(this, "TPKArvoCallHandlerJanuaryFirstScheduleRule", {
       schedule: events.Schedule.expression(
           `cron(5,25,45 6-18 1 JAN ? *)`
       ),
+      enabled: false,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
 

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -116,7 +116,7 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
     });
     new events.Rule(this, "TPKArvoCallHandlerJanuaryFirstScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 6-18 1 JAN ? *))`
+          `cron(5,25,45 6-18 1 JAN ? *)`
       ),
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -86,9 +86,9 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       enabled: false,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
     });
-    new events.Rule(this, "TPKNiputusHandlerJanuaryFirstScheduleRule", {
+    new events.Rule(this, "TPKNiputusHandlerFinalizingScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 0-5 1 JAN ? *)`
+          `cron(5,25,45 0-5 1 JAN,JUL ? *)`
       ),
       enabled: false,
       targets: [new targets.LambdaFunction(tpkNiputusHandler)]
@@ -117,9 +117,9 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       enabled: false,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]
     });
-    new events.Rule(this, "TPKArvoCallHandlerJanuaryFirstScheduleRule", {
+    new events.Rule(this, "TPKArvoCallHandlerFinalizingScheduleRule", {
       schedule: events.Schedule.expression(
-          `cron(5,25,45 6-18 1 JAN ? *)`
+          `cron(5,25,45 6-18 1 JAN,JUL ? *)`
       ),
       enabled: false,
       targets: [new targets.LambdaFunction(tpkArvoCallHandler)]


### PR DESCRIPTION
https://jira.eduuni.fi/browse/EH-1578

Ajastukset ovat nyt oletuksena pois päältä ja ne voidaan laittaa päälle lähempänä ajankohtaa, jos katsotaan että automaatiota halutaan käyttää. Muussa tapauksessa ajot voi ajaa kuten ennenkin.

QA:n AWS-konsolista voi käydä katsomassa, missä ajankohdissa säännöt ovat menossa ajoon. Esim:

* TPKArvoCallHandlerDefault
  * Next 10 trigger date(s)
    * Mon, 04 Dec 2023 06:05:00 UTC
    * Mon, 04 Dec 2023 06:25:00 UTC
    * Mon, 04 Dec 2023 06:45:00 UTC
    * Mon, 04 Dec 2023 07:05:00 UTC
    * Mon, 04 Dec 2023 07:25:00 UTC
    * Mon, 04 Dec 2023 07:45:00 UTC
    * Mon, 04 Dec 2023 08:05:00 UTC
    * Mon, 04 Dec 2023 08:25:00 UTC
    * Mon, 04 Dec 2023 08:45:00 UTC
    * Mon, 04 Dec 2023 09:05:00 UTC