### PR TITLE
EH-1406: Lopeta rahoitusryhmän päättely ja tallentaminen

### DIFF
--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -631,23 +631,6 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
       targets: [new targets.LambdaFunction(EhoksOpiskeluoikeusUpdateHandler)]
     });
 
-    const dbChanger = new lambda.Function(this, "dbChanger", {
-      runtime: this.runtime,
-      code: lambdaCode,
-      environment: {
-        ...this.envVars,
-        table: AMISherateTable.tableName,
-        caller_id: `1.2.246.562.10.00000000001.${id}-dbChanger`
-      },
-      handler: "oph.heratepalvelu.util.dbChanger::handleDBUpdate",
-      memorySize: 1024,
-      reservedConcurrentExecutions: 1,
-      timeout: Duration.seconds(900),
-      tracing: lambda.Tracing.ACTIVE
-    });
-
-    AMISherateTable.grantReadWriteData(dbChanger);
-
     /*
     const dbArchiver = new lambda.Function(this, "archiveHerateTable", {
       runtime: this.runtime,
@@ -684,7 +667,6 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
       AMISTimedOperationsHandler,
       AMISMassHerateResendHandler,
       EhoksOpiskeluoikeusUpdateHandler,
-      dbChanger,
       updateSmsLahetystila,
       // dbArchiver,
     ].forEach(

--- a/src/oph/heratepalvelu/amis/AMISCommon.clj
+++ b/src/oph/heratepalvelu/amis/AMISCommon.clj
@@ -74,9 +74,7 @@
           uuid (c/generate-uuid)
           oppilaitos (:oid (:oppilaitos opiskeluoikeus))
           suorituskieli (str/lower-case
-                          (:koodiarvo (:suorituskieli suoritus)))
-          rahoitusryhma (c/get-rahoitusryhma opiskeluoikeus
-                                             herate-date)]
+                          (:koodiarvo (:suorituskieli suoritus)))]
       (if-some [existing (c/already-superseding-herate! oppija
                                                         koulutustoimija
                                                         laskentakausi
@@ -128,7 +126,6 @@
                :hankintakoulutuksen-toteuttaja
                [:s (str (:hankintakoulutuksen_toteuttaja req-body))]
                :tallennuspvm        [:s (str (c/local-date-now))]
-               :rahoitusryhma       [:s rahoitusryhma]
                :herate-source       [:s herate-source]}
               db-data-cond-values
               (cond-> db-data

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -102,15 +102,6 @@
   [opiskeluoikeus date]
   (period-contains-date? (:erityinenTuki (:lisätiedot opiskeluoikeus)) date))
 
-(defn get-rahoitusryhma
-  "Päättää, mihin rahoitusryhmään oppilas kuuluu. Oppilas kuuluu rahoitusryhmään
-  1 jos hänen opinnot ovat maksuttomia tai hän on erityisen tuen opiskelijan."
-  [opiskeluoikeus ^LocalDate herate-date]
-  (if (or (is-maksuton? opiskeluoikeus (str herate-date))
-          (erityinen-tuki-voimassa? opiskeluoikeus (str herate-date)))
-    "01"
-    "02"))
-
 (defn has-time-to-answer?
   "Tarkistaa, onko aikaa jäljellä ennen annettua päivämäärää."
   [loppupvm]

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -143,9 +143,6 @@
               tutkinto      (get-in suoritus [:koulutusmoduuli
                                               :tunniste
                                               :koodiarvo])
-              rahoitusryhma (c/get-rahoitusryhma
-                              opiskeluoikeus
-                              (LocalDate/parse (:loppupvm herate)))
               db-data {:hankkimistapa_id     [:n tapa-id]
                        :hankkimistapa_tyyppi
                        [:s (last (str/split (:hankkimistapa-tyyppi herate)
@@ -183,8 +180,7 @@
                                 (:tyopaikan-ytunnus herate) "/"
                                 koulutustoimija "/" tutkinto)]
                        :tyopaikan_normalisoitu_nimi
-                       [:s (c/normalize-string (:tyopaikan-nimi herate))]
-                       :rahoitusryhma        [:s rahoitusryhma]}
+                       [:s (c/normalize-string (:tyopaikan-nimi herate))]}
               jaksotunnus-table-data
               (cond-> db-data
                 (not-empty (:tyopaikkaohjaaja-email herate))

--- a/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
@@ -66,9 +66,6 @@
                                             :koodiarvo])
             existing-arvo-tunnus
             (:tunnus (read-previously-processed-hankkimistapa tapa-id))
-            rahoitusryhma (->> (:loppupvm herate)
-                               (LocalDate/parse)
-                               (c/get-rahoitusryhma opiskeluoikeus))
             jakso {:hankkimistapa_id tapa-id
                    :oppija_oid (:oppija-oid herate)
                    :jakso_alkupvm (:alkupvm herate)
@@ -113,7 +110,6 @@
                               koulutustoimija "/" tutkinto)]
                      :tyopaikan_normalisoitu_nimi
                      [:s (c/normalize-string (:tyopaikan-nimi herate))]
-                     :rahoitusryhma        [:s rahoitusryhma]
                      :existing-arvo-tunnus [:s (str existing-arvo-tunnus)]
                      :vanha-kesto           [:n kesto-vanha]
                      ; NOTE: Uudessa laskutavassa osa-aikaisuutta ei oteta

--- a/test/oph/heratepalvelu/amis/AMISCommon_test.clj
+++ b/test/oph/heratepalvelu/amis/AMISCommon_test.clj
@@ -185,7 +185,6 @@
                              :hankintakoulutuksen-toteuttaja
                              [:s "test-hankintakoulutuksen-toteuttaja"]
                              :tallennuspvm [:s "2021-12-17"]
-                             :rahoitusryhma [:s "02"]
                              :herate-source [:s (:ehoks c/herate-sources)]}
                       :options
                       {:cond-expr "attribute_not_exists(kyselylinkki)"}}
@@ -243,7 +242,6 @@
                              :hankintakoulutuksen-toteuttaja
                              [:s "test-hankintakoulutuksen-toteuttaja"]
                              :tallennuspvm [:s "2021-12-17"]
-                             :rahoitusryhma [:s "02"]
                              :herate-source [:s (:koski c/herate-sources)]}
                       :options
                       {:cond-expr (str "attribute_not_exists(toimija_oppija) "
@@ -284,8 +282,7 @@
                      {:type     "mock-get-hankintakoulutuksen-toteuttaja",
                       :ehoks-id 98}
                      {:type    "mock-put-item",
-                      :item    {:rahoitusryhma [:s "02"],
-                                :kyselytyyppi [:s "tutkinnon_suorittaneet"],
+                      :item    {:kyselytyyppi [:s "tutkinnon_suorittaneet"],
                                 :request-id [:s "test-uuid"],
                                 :voimassa-loppupvm [:s "2022-01-15"],
                                 :hankintakoulutuksen-toteuttaja
@@ -369,7 +366,6 @@
                              :hankintakoulutuksen-toteuttaja
                              [:s "test-hankintakoulutuksen-toteuttaja"]
                              :tallennuspvm [:s "2021-12-17"]
-                             :rahoitusryhma [:s "02"]
                              :herate-source [:s (:ehoks c/herate-sources)]}
                       :options
                       {:cond-expr "attribute_not_exists(kyselylinkki)"}}

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISherateHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISherateHandler_i_test.clj
@@ -113,7 +113,6 @@
      :oppija-oid [:s "3.4.5"]
      :ehoks-id [:n "456"]
      :rahoituskausi [:s "2022-2023"]
-     :rahoitusryhma [:s "01"]
      :herate-source [:s (:ehoks c/herate-sources)]}})
 
 (def expected-http-results

--- a/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/UpdatedOpiskeluoikeusHandler_i_test.clj
@@ -162,7 +162,6 @@
      :oppija-oid [:s "1.2.3"]
      :ehoks-id [:n "123"]
      :rahoituskausi [:s "2022-2023"]
-     :rahoitusryhma [:s "02"]
      :herate-source [:s (:koski c/herate-sources)]}})
 
 (def expected-http-results

--- a/test/oph/heratepalvelu/integration_tests/tep/jaksoHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/jaksoHandler_i_test.clj
@@ -178,8 +178,7 @@
      :rahoituskausi [:s "2021-2022"]
      :tutkintonimike [:s "(\"test-tutkintonimike\")"]
      :viimeinen_vastauspvm [:s "2022-04-17"]
-     :request_id [:s "test-uuid"]
-     :rahoitusryhma [:s "02"]}})
+     :request_id [:s "test-uuid"]}})
 
 (def expected-nippu-table
   #{{:ohjaaja_ytunnus_kj_tutkinto

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -326,8 +326,7 @@
                        :oppija_oid [:s "123.456.789"]
                        :rahoituskausi [:s "2021-2022"]
                        :tutkintonimike [:s ""]
-                       :viimeinen_vastauspvm [:s "2022-02-14"]
-                       :rahoitusryhma [:s "02"]}
+                       :viimeinen_vastauspvm [:s "2022-02-14"]}
                       :nippu-table-data
                       {:tyopaikka [:s "Testityöpaikka"]
                        :koulutuksenjarjestaja [:s "koulutustoimija-id"]
@@ -437,8 +436,7 @@
                        :oppija_oid [:s "123.456.789"]
                        :rahoituskausi [:s "2021-2022"]
                        :tutkintonimike [:s ""]
-                       :viimeinen_vastauspvm [:s "2022-02-14"]
-                       :rahoitusryhma [:s "02"]}
+                       :viimeinen_vastauspvm [:s "2022-02-14"]}
                       :nippu-table-data
                       {:tyopaikka [:s "Testityöpaikka"]
                        :koulutuksenjarjestaja [:s "koulutustoimija-id"]


### PR DESCRIPTION
https://jira.eduuni.fi/browse/EH-1406

Aiemmin rahoitusryhmä poistettiin Arvoon lähetettävistä tiedoista, nyt siivotaan sen päättely ja tallentaminen pois myös Herätepalvelusta.

Tämän lisäksi tehdään Python-skripti, joka poistaa kantaan jo tallennetut rahoitusryhmätiedot. EDIT: Tässä voidaakin käyttää Severin [aiemmin tekemää](https://jira.eduuni.fi/secure/attachment/57761/57761_ddb-rm-attr-from-all-items.py) skriptiä rahoitusryhma-kentän poistamiseen.