### PR TITLE
Trim työpaikan nimi before saving heräte to DynamoDB

### DIFF
--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -2,7 +2,7 @@
   "Käsittelee työpaikkajaksoja, tallentaa niitä tietokantaan, ja valmistaa niitä
   niputukseen."
   (:require [cheshire.core :refer [parse-string]]
-            [clojure.string :as str]
+            [clojure.string :as str :refer [trim]]
             [clojure.tools.logging :as log]
             [environ.core :refer [env]]
             [oph.heratepalvelu.common :as c]
@@ -15,7 +15,6 @@
   (:import (clojure.lang ExceptionInfo)
            (com.amazonaws.services.lambda.runtime.events SQSEvent
                                                          SQSEvent$SQSMessage)
-           (com.fasterxml.jackson.core JsonParseException)
            (java.time LocalDate)
            (software.amazon.awssdk.awscore.exception AwsServiceException)
            (software.amazon.awssdk.services.dynamodb.model
@@ -132,7 +131,8 @@
   jaksotunnuksen Arvosta, luo jakson ja alusatavan nipun, ja tallentaa ne
   tietokantaan."
   [herate opiskeluoikeus koulutustoimija]
-  (let [tapa-id (:hankkimistapa-id herate)]
+  (let [herate (update herate :tyopaikan-nimi trim)
+        tapa-id (:hankkimistapa-id herate)]
     (log/info "Tallennetaan oht" tapa-id)
     (when (check-duplicate-hankkimistapa tapa-id)
       (try

--- a/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/jaksoHandler_test.clj
@@ -249,7 +249,7 @@
                             :oppilaitos {:oid "1234"}
                             :oid "567"}
             herate-open-keskeytymisajanjakso
-            {:tyopaikan-nimi "Testityöpaikka"
+            {:tyopaikan-nimi "  Testityöpaikka "
              :tyopaikan-ytunnus "765432-1"
              :tyopaikkaohjaaja-nimi "Testi Ojaaja"
              :alkupvm "2021-09-09"


### PR DESCRIPTION
https://jira.eduuni.fi/browse/EH-1579

Siivotaan työpaikan nimi ennen DynamoDB:hen tallentamista, jolloin ei saada jatkossa epämääräisiä alaviivalla `_` alkavia tai päättyviä normalisoituja nimiä.

Nimien ja normalisoitujen nimien takautuva korjaus tehdään erillisellä skriptillä.