### PR TITLE
EH-1686: Create new lambda for contact info cleaning

### DIFF
--- a/src/oph/heratepalvelu/tep/contactInfoCleaningHandler.clj
+++ b/src/oph/heratepalvelu/tep/contactInfoCleaningHandler.clj
@@ -1,0 +1,41 @@
+(ns oph.heratepalvelu.tep.contactInfoCleaningHandler
+  "Käsittelee ajastettuja työpaikkaohjaajien yhteistietojen siivouksia."
+  (:require [clojure.tools.logging :as log]
+            [environ.core :refer [env]]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
+            [oph.heratepalvelu.external.ehoks :as ehoks]))
+
+(gen-class
+  :name "oph.heratepalvelu.tep.contactInfoCleaningHandler"
+  :methods [[^:static cleanContactInfo
+             [com.amazonaws.services.lambda.runtime.events.ScheduledEvent
+              com.amazonaws.services.lambda.runtime.Context] void]])
+
+(defn -cleanContactInfo
+  "Käynnistää työpaikkaohjaajan yhteystietojen poiston."
+  [_ _ _]
+  (log/info "Käynnistetään työpaikkaohjaajan yhteystietojen poisto")
+  (let [hankkimistavat
+        (get-in (ehoks/delete-tyopaikkaohjaajan-yhteystiedot)
+                [:body :data :hankkimistapa-ids])
+        counter (atom 0)]
+    (doseq [hankkimistapa_id hankkimistavat]
+      (log/info "Käsitellään oht" hankkimistapa_id)
+      (let [resp (ddb/scan {:filter-expression   "#id = :id"
+                            :expr-attr-names     {"#id" "hankkimistapa_id"}
+                            :expr-attr-vals      {":id" [:n hankkimistapa_id]}}
+                           (:jaksotunnus-table env))
+            items (:items resp)]
+        (when (seq items)
+          (log/info "Poistetaan ohjaajan yhteystiedot (hankkimistapa_id = "
+                    hankkimistapa_id
+                    ")")
+          (ddb/update-item
+            {:hankkimistapa_id [:n hankkimistapa_id]}
+            {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
+             :expr-attr-names {"#eml" "ohjaaja_email"
+                               "#puh" "ohjaaja_puhelinnumero"}
+             :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
+            (:jaksotunnus-table env))
+          (swap! counter inc))))
+    (log/info "Poistettu" @counter "ohjaajan yhteystiedot")))

--- a/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
+++ b/src/oph/heratepalvelu/tep/ehoksTimedOperationsHandler.clj
@@ -1,9 +1,7 @@
 (ns oph.heratepalvelu.tep.ehoksTimedOperationsHandler
   "Käsittelee ajastettuja operaatioita TEP-puolella."
   (:require [clojure.tools.logging :as log]
-            [environ.core :refer [env]]
             [oph.heratepalvelu.common :as c]
-            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.external.ehoks :as ehoks]))
 
 (gen-class
@@ -21,30 +19,4 @@
                (str (c/current-rahoituskausi-alkupvm))
                (str (c/local-date-now))
                1500)]
-    (log/info "Lähetetty" (:data (:body resp)) "viestiä"))
-
-  (log/info "Käynnistetään työpaikkaohjaajan yhteystietojen poisto")
-  (let [hankkimistavat
-        (get-in (ehoks/delete-tyopaikkaohjaajan-yhteystiedot)
-                [:body :data :hankkimistapa-ids])
-        counter (atom 0)]
-    (doseq [hankkimistapa_id hankkimistavat]
-      (log/info "Käsitellään oht" hankkimistapa_id)
-      (let [resp (ddb/scan {:filter-expression   "#id = :id"
-                            :expr-attr-names     {"#id" "hankkimistapa_id"}
-                            :expr-attr-vals      {":id" [:n hankkimistapa_id]}}
-                           (:jaksotunnus-table env))
-            items (:items resp)]
-        (when (seq items)
-          (log/info "Poistetaan ohjaajan yhteystiedot (hankkimistapa_id = "
-                    hankkimistapa_id
-                    ")")
-          (ddb/update-item
-            {:hankkimistapa_id [:n hankkimistapa_id]}
-            {:update-expr "SET #eml = :eml_value, #puh = :puh_value"
-             :expr-attr-names {"#eml" "ohjaaja_email"
-                               "#puh" "ohjaaja_puhelinnumero"}
-             :expr-attr-vals {":eml_value" [:s ""] ":puh_value" [:s ""]}}
-            (:jaksotunnus-table env))
-          (swap! counter inc))))
-    (log/info "Poistettu" @counter "ohjaajan yhteystiedot")))
+    (log/info "Lähetetty" (:data (:body resp)) "viestiä")))

--- a/test/oph/heratepalvelu/integration_tests/tep/contactInfoCleaningHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/contactInfoCleaningHandler_i_test.clj
@@ -1,11 +1,12 @@
-(ns oph.heratepalvelu.integration-tests.tep.ehoksTimedOperationsHandler-i-test
+(ns oph.heratepalvelu.integration-tests.tep.contactInfoCleaningHandler-i-test
   (:require [clojure.test :refer [deftest is testing]]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.integration-tests.mock-cas-client :as mcc]
+            [oph.heratepalvelu.integration-tests.mock-db :as mdb]
             [oph.heratepalvelu.integration-tests.mock-http-client :as mhc]
-            [oph.heratepalvelu.tep.ehoksTimedOperationsHandler :as etoh]
-            [oph.heratepalvelu.test-util :as tu]
-            [oph.heratepalvelu.integration-tests.mock-db :as mdb])
-  (:import (java.time LocalDate)))
+            [oph.heratepalvelu.tep.contactInfoCleaningHandler
+             :refer [-cleanContactInfo]]
+            [oph.heratepalvelu.test-util :as tu]))
 
 (def mock-env {:ehoks-url "https://oph-ehoks.com/"
                :jaksotunnus-table "jaksotunnus-table"})
@@ -56,36 +57,47 @@
   (mdb/clear-mock-db))
 
 (def expected-http-results
-  [{:method :get
-    :url "https://oph-ehoks.com/heratepalvelu/tyoelamajaksot"
+  [{:method :delete
+    :url "https://oph-ehoks.com/heratepalvelu/tyopaikkaohjaajan-yhteystiedot"
     :options
     {:headers {:ticket
                "service-ticket/ehoks-virkailija-backend/cas-security-check"}
-     :as :json
-     :query-params {:start "2021-07-01" :end "2022-02-02" :limit 1500}}}])
+     :as :json}}])
 
 (def expected-cas-client-results [{:type :get-service-ticket
                                    :service "/ehoks-virkailija-backend"
                                    :suffix "cas-security-check"}])
 
-(deftest test-ehoksTimedOperationsHandler-integration
-  (testing "ehoksTimedIntegrationsHandler integraatiotesti"
+(deftest test-contactInfoCleaningHandler-integration
+  (testing "contactInfoCleaningHandler integraatiotesti"
     (with-redefs [clojure.tools.logging/log* tu/mock-log*
                   environ.core/env mock-env
-                  oph.heratepalvelu.common/local-date-now
-                  (fn [] (LocalDate/of 2022 2 2))
                   oph.heratepalvelu.external.cas-client/get-service-ticket
                   mcc/mock-get-service-ticket
-                  oph.heratepalvelu.external.http-client/get mhc/mock-get]
+                  oph.heratepalvelu.external.http-client/delete mhc/mock-delete
+                  ddb/scan mdb/scan
+                  ddb/update-item mdb/update-item]
       (setup-test)
-      (etoh/-handleTimedOperations {}
-                                   (tu/mock-handler-event :scheduledherate)
-                                   (tu/mock-handler-context))
+      (-cleanContactInfo {}
+                         (tu/mock-handler-event :scheduledherate)
+                         (tu/mock-handler-context))
       (is (= (mcc/get-results) expected-cas-client-results))
       (is (= (mhc/get-results) expected-http-results))
       (is (true? (tu/logs-contain?
                    {:level :info
-                    :message "Käynnistetään jaksojen lähetys"})))
-      (is (true? (tu/logs-contain? {:level :info
-                                    :message "Lähetetty 2 viestiä"})))
+                    :message
+                    "Käynnistetään työpaikkaohjaajan yhteystietojen poisto"})))
+      (is (true? (tu/logs-contain?
+                   {:level :info
+                    :message "Poistettu 3 ohjaajan yhteystiedot"})))
+      (is (= (mdb/get-table-values (:jaksotunnus-table mock-env))
+             #{{:hankkimistapa_id [:n 1]
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}
+               {:hankkimistapa_id [:n 2]
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}
+               {:hankkimistapa_id [:n 3]
+                :ohjaaja_email [:s ""]
+                :ohjaaja_puhelinnumero [:s ""]}}))
       (teardown-test))))

--- a/test/oph/heratepalvelu/tep/contactInfoCleaningHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/contactInfoCleaningHandler_test.clj
@@ -1,0 +1,47 @@
+(ns oph.heratepalvelu.tep.contactInfoCleaningHandler-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :as log]
+            [oph.heratepalvelu.db.dynamodb :as ddb]
+            [oph.heratepalvelu.external.ehoks :as ehoks]
+            [oph.heratepalvelu.tep.contactInfoCleaningHandler
+             :refer [-cleanContactInfo]]
+            [oph.heratepalvelu.test-util :as tu]))
+
+(def delete-endpoint-called (atom false))
+(def scan-called (atom 0))
+(def update-item-called (atom 0))
+
+(defn- mock-delete-call []
+  (reset! delete-endpoint-called true)
+  {:body {:data {:hankkimistapa-ids [1 2 3]}}})
+
+(defn- mock-scan [_ __]
+  (swap! scan-called inc)
+  {:items [{:hankkimistapa_id [:n @scan-called]
+            :sahkoposti [:s "testi@oph.fi"]
+            :puhelinnumero [:s "0401111111"]}]})
+
+(defn- mock-update-item [_ __ ___]
+  (swap! update-item-called inc))
+
+(deftest test-cleanContactInfo
+  (testing "Varmista, että -cleanContactInfo siivoaa yhteystiedot"
+    (with-redefs
+      [log/log* tu/mock-log*
+       ehoks/delete-tyopaikkaohjaajan-yhteystiedot mock-delete-call
+       ddb/scan mock-scan
+       ddb/update-item mock-update-item]
+      (let [event (tu/mock-handler-event :scheduledherate)
+            context (tu/mock-handler-context)]
+        (-cleanContactInfo {} event context)
+        (is (true?
+              (tu/logs-contain?
+                {:level :info
+                 :message
+                 "Käynnistetään työpaikkaohjaajan yhteystietojen poisto"})))
+        (is (= @scan-called 3))
+        (is (= @update-item-called 3))
+        (is (true? @delete-endpoint-called))
+        (is (true? (tu/logs-contain?
+                     {:level :info
+                      :message "Poistettu 3 ohjaajan yhteystiedot"})))))))

--- a/test/oph/heratepalvelu/tep/ehoksTimedOperationsHandler_test.clj
+++ b/test/oph/heratepalvelu/tep/ehoksTimedOperationsHandler_test.clj
@@ -1,44 +1,24 @@
 (ns oph.heratepalvelu.tep.ehoksTimedOperationsHandler-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [oph.heratepalvelu.tep.ehoksTimedOperationsHandler :as etoh]
             [oph.heratepalvelu.external.ehoks :as ehoks]
-            [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.test-util :as tu])
   (:import (java.time LocalDate)))
 
 (use-fixtures :each tu/clear-logs-before-test)
 
 (def results (atom {}))
-(def delete-endpoint-called (atom false))
-(def scan-called (atom 0))
-(def update-item-called (atom 0))
 
 (defn- mock-get-paattyneet-tyoelamajaksot [start end limit]
   (reset! results {:start start :end end})
   {:body {:data limit}})
-
-(defn- mock-delete-call []
-  (reset! delete-endpoint-called true)
-  {:body {:data {:hankkimistapa-ids [1 2 3]}}})
-
-(defn- mock-scan [_ __]
-  (swap! scan-called inc)
-  {:items [{:hankkimistapa_id [:n @scan-called]
-            :sahkoposti [:s "testi@oph.fi"]
-            :puhelinnumero [:s "0401111111"]}]})
-
-(defn- mock-update-item [_ __ ___]
-  (swap! update-item-called inc))
 
 (deftest test-handleTimedOperations
   (testing "Varmista, että -handleTimedOperations kutsuu ehoks-palvelua oikein"
     (with-redefs
       [clojure.tools.logging/log* tu/mock-log*
        oph.heratepalvelu.common/local-date-now (fn [] (LocalDate/of 2021 10 10))
-       ehoks/get-paattyneet-tyoelamajaksot mock-get-paattyneet-tyoelamajaksot
-       ehoks/delete-tyopaikkaohjaajan-yhteystiedot mock-delete-call
-       ddb/scan mock-scan
-       ddb/update-item mock-update-item]
+       ehoks/get-paattyneet-tyoelamajaksot mock-get-paattyneet-tyoelamajaksot]
       (let [event (tu/mock-handler-event :scheduledherate)
             context (tu/mock-handler-context)
             expected {:start "2021-07-01" :end "2021-10-10"}]
@@ -49,16 +29,4 @@
                       :message "Käynnistetään jaksojen lähetys"})))
         (is (true? (tu/logs-contain?
                      {:level :info
-                      :message "Lähetetty 1500 viestiä"})))
-
-        (is (true?
-              (tu/logs-contain?
-                {:level :info
-                 :message
-                 "Käynnistetään työpaikkaohjaajan yhteystietojen poisto"})))
-        (is (= @scan-called 3))
-        (is (= @update-item-called 3))
-        (is (true? @delete-endpoint-called))
-        (is (true? (tu/logs-contain?
-                     {:level :info
-                      :message "Poistettu 3 ohjaajan yhteystiedot"})))))))
+                      :message "Lähetetty 1500 viestiä"})))))))


### PR DESCRIPTION
timedOperationsHandler-lambda epäonnistui timeouteihin ja aiheutti ongelmia mm. työpaikkajaksojen käsittelyssä (kts. Slack-keskustelu https://opetushallitus.slack.com/archives/C03JN1DGD53/p1717587552619319?thread_ts=1717571706.223229&cid=C03JN1DGD53). Tein uuden lambdan työpaikkaohjaajien yhteystietojen siivoamiselle.

https://jira.eduuni.fi/browse/EH-1514