### PR TITLE
EH-1683: poistetaan rahoituskauden viimeisen niputuksen erikoiskäsittely

### DIFF
--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -206,10 +206,9 @@
                                              (str/split pvm-str #"-"))]
     (if (< day 16)
       (LocalDate/of year month 16)
-      (cond
-        (= 6 month) (LocalDate/of year 6 30)
-        (= 12 month) (LocalDate/of (inc year) 1 1)
-        :else (LocalDate/of year (inc month) 1)))))
+      (if (= 12 month)
+        (LocalDate/of (inc year) 1 1)
+        (LocalDate/of year (inc month) 1)))))
 
 (defn- deaccent-string
   "Poistaa diakriittiset merkit stringistä ja palauttaa muokatun stringin."

--- a/test/oph/heratepalvelu/common_test.clj
+++ b/test/oph/heratepalvelu/common_test.clj
@@ -240,7 +240,7 @@
     (is (= (LocalDate/of 2021 12 16) (next-niputus-date "2021-12-03")))
     (is (= (LocalDate/of 2022 1 1) (next-niputus-date "2021-12-27")))
     (is (= (LocalDate/of 2021 5 1) (next-niputus-date "2021-04-25")))
-    (is (= (LocalDate/of 2022 6 30) (next-niputus-date "2022-06-24")))))
+    (is (= (LocalDate/of 2022 7 1) (next-niputus-date "2022-06-24")))))
 
 (deftest test-doseq-with-timeout
   (testing "Doseq with timeout goes over seq and stops if timeout happens"


### PR DESCRIPTION
Heijastuu eHOKSiin siirrettyyn toiminnallisuuteen: https://github.com/Opetushallitus/ehoks/pull/620