### PR TITLE
Add error metric filters for `amis`, `tep`, and `tpk` log groups

### DIFF
--- a/cdk/lib/amis.ts
+++ b/cdk/lib/amis.ts
@@ -220,6 +220,8 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
       logGroupName: `${envName}-heratepalvelu-amis`,
       retention: RetentionDays.TWO_YEARS,
     });
+    
+    this.createErrorMetricFilter('amis', amisLogGroup);
 
     const AMISHerateHandler = new lambda.Function(this, "AMISHerateHandler", {
       runtime: this.runtime,
@@ -743,7 +745,6 @@ export class HeratepalveluAMISStack extends HeratepalveluStack {
           resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
           actions: ['ssm:GetParameter']
         }));
-        this.createMetricFilters(lambdaFunction);
       }
     );
   }

--- a/cdk/lib/heratepalvelu.ts
+++ b/cdk/lib/heratepalvelu.ts
@@ -1,6 +1,6 @@
 import { Stack, App, StackProps, Tags } from 'aws-cdk-lib';
 import lambda = require("aws-cdk-lib/aws-lambda");
-import { FilterPattern, MetricFilter } from 'aws-cdk-lib/aws-logs';
+import { FilterPattern, LogGroup, MetricFilter } from 'aws-cdk-lib/aws-logs';
 import ssm = require("aws-cdk-lib/aws-ssm");
 
 export type EnvVars = {
@@ -59,15 +59,13 @@ export class HeratepalveluStack extends Stack {
     this.runtime = lambda.Runtime.JAVA_11;
   }
 
-  createMetricFilters = (lambdaFunction: lambda.Function) => {
+  createErrorMetricFilter = (stack: string, logGroup: LogGroup) => {
       const metricNamespace = 'OpintopolkuLogMetrics';
-      const logGroup = lambdaFunction.logGroup;
-      const functionName = lambdaFunction.node.id;
-      new MetricFilter(this, `${functionName}LogErrors`, {
+      new MetricFilter(this, `${stack}LogErrors`, {
         logGroup,
         metricNamespace: metricNamespace,
-        metricName: `${this.envName}/heratepalvelu/${functionName}/errors`,
-        filterPattern: FilterPattern.literal('ERROR'),
+        metricName: `${this.envName}/heratepalvelu/${stack}/errors`,
+        filterPattern: FilterPattern.stringValue('$.level', '=', 'ERROR'),
         metricValue: "1"
       });
   }

--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -274,6 +274,10 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
       retention: RetentionDays.TWO_YEARS,
     });
 
+    // MetricFilter
+    
+    this.createErrorMetricFilter('tep', tepLogGroup);
+
     // VPC
 
     const vpc = ec2.Vpc.fromVpcAttributes(this, "VPC", {
@@ -673,7 +677,6 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
             resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
             actions: ['ssm:GetParameter']
           }));
-          this.createMetricFilters(lambdaFunction);
         }
     );
   }

--- a/cdk/lib/tpk.ts
+++ b/cdk/lib/tpk.ts
@@ -107,6 +107,10 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
       retention: RetentionDays.TWO_YEARS,
     });
 
+    // MetricFilter
+    
+    this.createErrorMetricFilter('tpk', tpkLogGroup);
+
     // VPC
 
     const vpc = ec2.Vpc.fromVpcAttributes(this, "VPC", {
@@ -230,7 +234,6 @@ export class HeratepalveluTPKStack extends HeratepalveluStack {
           resources: [`arn:aws:ssm:eu-west-1:*:parameter/${envName}/services/heratepalvelu/*`],
           actions: ["ssm:GetParameter"],
         }));
-        this.createMetricFilters(lambdaFunction);
       }
     );
   }


### PR DESCRIPTION
Virheiden lukumääriä seuraavat metriikat `amis`, `tep` ja `tpk` lokiryhmille: https://jira.eduuni.fi/browse/EH-1693