### PR TITLE
EH-1697: Työpaikkajakson yksilöivä tunniste tallentumaan Herätepalveluun

### DIFF
--- a/cdk/lib/tep.ts
+++ b/cdk/lib/tep.ts
@@ -49,6 +49,19 @@ export class HeratepalveluTEPStack extends HeratepalveluStack {
     });
 
     jaksotunnusTable.addGlobalSecondaryIndex({
+      indexName: "yksiloivaTunnisteIndex",
+      partitionKey: {
+        name: "hoks_id",
+        type: dynamodb.AttributeType.NUMBER
+      },
+      sortKey: {
+        name: "yksiloiva_tunniste",
+        type: dynamodb.AttributeType.STRING
+      },
+      projectionType: dynamodb.ProjectionType.ALL
+    });
+
+    jaksotunnusTable.addGlobalSecondaryIndex({
       indexName: "tepDbChangerIndex",
       partitionKey: {
         name: "oppija_oid",

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -59,9 +59,10 @@
   "TEP-herätescheman tarkistusfunktio."
   (s/checker tep-herate-schema))
 
-(defn check-duplicate-jakso
+(defn not-duplicate-jakso?!
   "Palauttaa `true`, jos ei ole vielä jaksoa tietokannassa annetulla HOKS ID:llä
-  ja jakson yksilöivällä tunnisteella."
+  ja jakson yksilöivällä tunnisteella, eikä myöskään osaamisen hankkimistapa
+  ID:llä."
   [hoks-id yksiloiva-tunniste hankkimistapa-id]
   (if (and (empty? (ddb/get-item {:hankkimistapa_id [:n hankkimistapa-id]}
                                  (:jaksotunnus-table env)))
@@ -153,7 +154,7 @@
       hoks-id
       yksiloiva-tunniste
       hankkimistapa-id)
-    (when (check-duplicate-jakso hoks-id yksiloiva-tunniste hankkimistapa-id)
+    (when (not-duplicate-jakso?! hoks-id yksiloiva-tunniste hankkimistapa-id)
       (try
         (let [request-id    (c/generate-uuid)
               niputuspvm    (c/next-niputus-date (str (c/local-date-now)))

--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -144,14 +144,16 @@
   tietokantaan."
   [herate opiskeluoikeus koulutustoimija]
   (let [herate             (update herate :tyopaikan-nimi trim)
-        tapa-id            (:hankkimistapa-id herate)
+        hankkimistapa-id   (:hankkimistapa-id herate)
         hoks-id            (:hoks-id herate)
         yksiloiva-tunniste (:yksiloiva-tunniste herate)]
     (log/infof
-      "Tallennetaan jakso HOKS ID:llä `%d` ja yksilöivällä tunnisteella `%s`."
+      (str "Tallennetaan jakso HOKS ID:llä `%d` ja yksilöivällä tunnisteella "
+           "`%s` (osaamisen hankkimistapa `%d`).")
       hoks-id
-      yksiloiva-tunniste)
-    (when (check-duplicate-jakso hoks-id yksiloiva-tunniste tapa-id)
+      yksiloiva-tunniste
+      hankkimistapa-id)
+    (when (check-duplicate-jakso hoks-id yksiloiva-tunniste hankkimistapa-id)
       (try
         (let [request-id    (c/generate-uuid)
               niputuspvm    (c/next-niputus-date (str (c/local-date-now)))
@@ -160,7 +162,7 @@
               tutkinto      (get-in suoritus [:koulutusmoduuli
                                               :tunniste
                                               :koodiarvo])
-              db-data {:hankkimistapa_id     [:n tapa-id]
+              db-data {:hankkimistapa_id     [:n hankkimistapa-id]
                        :hankkimistapa_tyyppi
                        [:s (last (str/split (:hankkimistapa-tyyppi herate)
                                             #"_"))]
@@ -243,9 +245,11 @@
               (catch ConditionalCheckFailedException _
                 (log/warnf
                   (str "Osaamisen hankkimistapa HOKS ID:llä `%d` ja "
-                       "yksilöivällä tunnisteella `%s` on jo käsitelty.")
+                       "yksilöivällä tunnisteella `%s` (osaamisen "
+                       "hankkimistapa `%d`) on jo käsitelty.")
                   hoks-id
-                  yksiloiva-tunniste))
+                  yksiloiva-tunniste
+                  hankkimistapa-id))
               (catch AwsServiceException e
                 (log/error "Virhe tietokantaan tallennettaessa, request-id"
                            request-id)
@@ -272,9 +276,11 @@
                 (catch ConditionalCheckFailedException _
                   (log/warnf
                     (str "Osaamisen hankkimistapa HOKS ID:llä `%d` ja "
-                         "yksilöivällä tunnisteella `%s` on jo käsitelty.")
+                         "yksilöivällä tunnisteella `%s` (osaamisen "
+                         "hankkimistapa `%d`) on jo käsitelty.")
                     hoks-id
-                    yksiloiva-tunniste)
+                    yksiloiva-tunniste
+                    hankkimistapa-id)
                   (arvo/delete-jaksotunnus tunnus))
                 (catch AwsServiceException e
                   (log/error "Virhe tietokantaan tallennettaessa"

--- a/test/oph/heratepalvelu/integration_tests/tep/jaksoHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/tep/jaksoHandler_i_test.clj
@@ -22,6 +22,7 @@
                   :alkupvm "2022-01-05"
                   :loppupvm "2022-02-02"
                   :hoks-id 123
+                  :yksiloiva-tunniste "1234"
                   :opiskeluoikeus-oid "test-oo-oid"
                   :oppija-oid "test-oppija-oid"
                   :hankkimistapa-id 234
@@ -44,7 +45,8 @@
          :oppija-oid "test-extfund-oppija-oid"
          :opiskeluoikeus-oid "test-oo-oid-externalfunding"
          :hankkimistapa-id 456
-         :hoks-id 345))
+         :hoks-id 345
+         :yksiloiva-tunniste "2345"))
 
 (def test-herate-missing-osa-aikaisuus
   (assoc test-herate
@@ -54,10 +56,11 @@
 (def duplicate-herate {:tyyppi "aloittaneet"
                        :alkupvm "2022-01-01"
                        :loppupvm "2022-02-06"
-                       :hoks-id 789
+                       :hoks-id 123
+                       :yksiloiva-tunniste "1234"
                        :opiskeluoikeus-oid "test-oo-oid2"
                        :oppija-oid "test-oppija-oid2"
-                       :hankkimistapa-id 234
+                       :hankkimistapa-id 567
                        :hankkimistapa-tyyppi "koulutussopimus"
                        :tutkinnonosa-id 2
                        :tutkinnonosa-koodi "test-tutkinnonosa2"
@@ -154,6 +157,7 @@
      :opiskeluoikeus_oid [:s "test-oo-oid"]
      :hankkimistapa_tyyppi [:s "oppisopimus"]
      :hoks_id [:n 123]
+     :yksiloiva_tunniste [:s "1234"]
      :oppisopimuksen_perusta [:s "01"]
      :tyopaikan_nimi [:s "Testi Oy"]
      :tyopaikan_ytunnus [:s "123456-7"]
@@ -238,7 +242,7 @@
     :options {:basic-auth ["koski-user" "koski-pwd"] :as :json}}
    {:method :patch
     :url (str (:ehoks-url mock-env)
-              "heratepalvelu/osaamisenhankkimistavat/234/kasitelty")
+              "heratepalvelu/osaamisenhankkimistavat/567/kasitelty")
     :options {:headers {:ticket (str "service-ticket/ehoks-virkailija-backend"
                                      "/cas-security-check")}
               :content-type "application/json"


### PR DESCRIPTION
Yksilöivä tunniste tallentumaan Herätepalveluun. Käytetään jaksojen yksilöintiin hankkimistapa ID:n sijasta HOKS ID:tä ja jakson yksilöivää tunnistetta.

https://jira.eduuni.fi/browse/EH-1697