### PR TITLE
Remove underscore prefixes and postfixes from normalized names

### DIFF
--- a/src/oph/heratepalvelu/tep/jaksoHandler.clj
+++ b/src/oph/heratepalvelu/tep/jaksoHandler.clj
@@ -11,6 +11,7 @@
             [oph.heratepalvelu.external.ehoks :as ehoks]
             [oph.heratepalvelu.external.koski :as koski]
             [oph.heratepalvelu.log.caller-log :refer [log-caller-details-sqs]]
+            [oph.heratepalvelu.util.string :as u-str]
             [schema.core :as s])
   (:import (clojure.lang ExceptionInfo)
            (com.amazonaws.services.lambda.runtime.events SQSEvent
@@ -201,7 +202,7 @@
                                 (:tyopaikan-ytunnus herate) "/"
                                 koulutustoimija "/" tutkinto)]
                        :tyopaikan_normalisoitu_nimi
-                       [:s (c/normalize-string (:tyopaikan-nimi herate))]}
+                       [:s (u-str/normalize (:tyopaikan-nimi herate))]}
               jaksotunnus-table-data
               (cond-> db-data
                 (not-empty (:tyopaikkaohjaaja-email herate))
@@ -258,7 +259,7 @@
             (let [arvo-resp (arvo/create-jaksotunnus
                               (arvo/build-jaksotunnus-request-body
                                 herate
-                                (c/normalize-string (:tyopaikan-nimi herate))
+                                (u-str/normalize (:tyopaikan-nimi herate))
                                 opiskeluoikeus
                                 request-id
                                 koulutustoimija

--- a/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
+++ b/src/oph/heratepalvelu/tep/rahoitusLaskentaHandler.clj
@@ -16,14 +16,13 @@
             [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.external.arvo :as arvo]
             [oph.heratepalvelu.external.koski :as koski]
+            [oph.heratepalvelu.log.caller-log :refer [log-caller-details-sqs]]
             [oph.heratepalvelu.tep.jaksoHandler :as jh]
             [oph.heratepalvelu.tep.niputusHandler :as nh]
-            [oph.heratepalvelu.log.caller-log :refer [log-caller-details-sqs]])
+            [oph.heratepalvelu.util.string :as u-str])
   (:import (clojure.lang ExceptionInfo)
            (com.amazonaws.services.lambda.runtime.events SQSEvent
                                                          SQSEvent$SQSMessage)
-           (com.fasterxml.jackson.core JsonParseException)
-           (java.time LocalDate)
            (software.amazon.awssdk.awscore.exception AwsServiceException)
            (software.amazon.awssdk.services.dynamodb.model
              ConditionalCheckFailedException)))
@@ -109,7 +108,7 @@
                               (:tyopaikan-ytunnus herate) "/"
                               koulutustoimija "/" tutkinto)]
                      :tyopaikan_normalisoitu_nimi
-                     [:s (c/normalize-string (:tyopaikan-nimi herate))]
+                     [:s (u-str/normalize (:tyopaikan-nimi herate))]
                      :existing-arvo-tunnus [:s (str existing-arvo-tunnus)]
                      :vanha-kesto           [:n kesto-vanha]
                      ; NOTE: Uudessa laskutavassa osa-aikaisuutta ei oteta

--- a/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
+++ b/src/oph/heratepalvelu/tpk/tpkNiputusHandler.clj
@@ -1,12 +1,13 @@
 (ns oph.heratepalvelu.tpk.tpkNiputusHandler
   "Käsittelee TPK:n niputusta ja tallennusta herätepalvelun tietokantaan."
-  (:require [clojure.tools.logging :as log]
-            [clojure.core.memoize :refer [memo]]
+  (:require [clojure.core.memoize :refer [memo]]
+            [clojure.tools.logging :as log]
             [environ.core :refer [env]]
             [oph.heratepalvelu.common :as c]
             [oph.heratepalvelu.db.dynamodb :as ddb]
             [oph.heratepalvelu.log.caller-log :refer :all]
-            [oph.heratepalvelu.tpk.tpkCommon :as tpkc])
+            [oph.heratepalvelu.tpk.tpkCommon :as tpkc]
+            [oph.heratepalvelu.util.string :as u-str])
   (:import (java.time LocalDate)
            (software.amazon.awssdk.awscore.exception AwsServiceException)))
 
@@ -32,7 +33,7 @@
   "Luo nipputunnisteen työpaikan normalisoidun nimen, työpaikan Y-tunnuksen,
   koulutustoimijan ja tiedonkeruukauden perustella."
   [jakso]
-  (str (c/normalize-string (:tyopaikan_nimi jakso)) "/"
+  (str (u-str/normalize (:tyopaikan_nimi jakso)) "/"
        (:tyopaikan_ytunnus jakso) "/"
        (:koulutustoimija jakso) "/"
        (tpkc/get-kausi-alkupvm (LocalDate/parse (:jakso_loppupvm jakso))) "_"
@@ -68,7 +69,7 @@
                          (LocalDate/parse (:jakso_loppupvm jakso)))]
     {:nippu-id                    (create-nippu-id jakso)
      :tyopaikan-nimi              (:tyopaikan_nimi jakso)
-     :tyopaikan-nimi-normalisoitu (c/normalize-string (:tyopaikan_nimi jakso))
+     :tyopaikan-nimi-normalisoitu (u-str/normalize (:tyopaikan_nimi jakso))
      :vastaamisajan-alkupvm       (str alkupvm)
      :vastaamisajan-loppupvm      (str loppupvm)
      :tyopaikan-ytunnus           (:tyopaikan_ytunnus jakso)

--- a/src/oph/heratepalvelu/util/string.clj
+++ b/src/oph/heratepalvelu/util/string.clj
@@ -1,0 +1,21 @@
+(ns oph.heratepalvelu.util.string
+  (:require [clojure.string :as str])
+  (:import (java.text Normalizer Normalizer$Form)))
+
+(defn- deaccent
+  "Poistaa diakriittiset merkit merkkijonosta ja palauttaa muokatun
+  merkkijonon."
+  [utf8-string]
+  (str/replace (Normalizer/normalize utf8-string Normalizer$Form/NFD)
+               #"\p{InCombiningDiacriticalMarks}+"
+               ""))
+
+(defn normalize
+  "Convert non-alphanumeric characters to underscore characters  (`_`) and
+  make letters lower case. If the resulting string has an underscore character
+  as a prefix or postfix, those underscore characters are removed."
+  [string]
+  (-> (deaccent string)
+      (str/replace #"\W+" "_")
+      (str/replace #"(^_|_$)" "")
+      (str/lower-case)))

--- a/test/oph/heratepalvelu/util/string_test.clj
+++ b/test/oph/heratepalvelu/util/string_test.clj
@@ -1,0 +1,22 @@
+(ns oph.heratepalvelu.util.string-test
+  (:require [clojure.test :refer [are deftest is testing]]
+            [oph.heratepalvelu.util.string :refer [normalize]]))
+
+(deftest test-normalize
+  (testing "Characters with diacritics are converted to ASCII characters."
+    (is (= (normalize "äåéëúíóöáïñ") "aaeeuiooain")))
+  (testing "Whitespace characters are replaced with underscore (`_`)."
+    (are [string expected] (= (normalize string) expected)
+      "a b" "a_b"   "a\nb" "a_b"   "a\tb" "a_b"   "a\r\nb" "a_b"))
+  (testing "Uppercase characters will be converted to lower case."
+    (is (= (normalize "ABCDEF") "abcdef")))
+  (testing "There won't be consecutive underscore characters."
+    (are [string expected] (= (normalize string) expected)
+      "a!#$b" "a_b"   "!#$ab^&*" "ab"))
+  (testing "Non-alphanumeric characters are converted to underscores (`_`)."
+    (is (= (normalize "a!b@c#d$e%f^g&h*i(j)k_l+m-n=o\"p'q]r[s{t}u\\v|w/x.y,z")
+           "a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x_y_z")))
+  (testing (str "The function strips underscore characters (`_`) from the "
+                "beginning and the end of the string.")
+    (are [string expected] (= (normalize string) expected)
+      "Severi (testaaja)" "severi_testaaja"   "#testi" "testi")))


### PR DESCRIPTION
Poistetaan alaviivat työpaikkajaksojen normalisoitujen nimien alusta ja lopusta. Lisätty testejä.

https://jira.eduuni.fi/browse/EH-1747