### PR TITLE
EH-1816: Use `:ehoks-id` or `:ehoks_id`

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISCommon.clj
+++ b/src/oph/heratepalvelu/amis/AMISCommon.clj
@@ -58,7 +58,7 @@
 (defn check-and-save-herate!
   "Tarkistaa herätteen ja tallentaa sen tietokantaan."
   [herate opiskeluoikeus koulutustoimija herate-source]
-  (log/info "Kerätään tietoja " (:ehoks-id herate) " " (:kyselytyyppi herate))
+  (log/info "Kerätään tietoja " (c/hoks-id herate) " " (:kyselytyyppi herate))
   (if-some [errors (c/herate-schema-errors herate)]
     (log/error "Heräte" herate "ei vastaa skeemaa:" errors)
     (let [kyselytyyppi (:kyselytyyppi herate)
@@ -114,7 +114,7 @@
                :heratepvm           [:s heratepvm]
                :request-id          [:s uuid]
                :oppilaitos          [:s oppilaitos]
-               :ehoks-id            [:n (str (:ehoks-id herate))]
+               :ehoks-id            [:n (str (c/hoks-id herate))]
                :opiskeluoikeus-oid  [:s (:oid opiskeluoikeus)]
                :oppija-oid          [:s oppija]
                :koulutustoimija     [:s koulutustoimija]
@@ -143,7 +143,7 @@
           (when (c/has-nayttotutkintoonvalmistavakoulutus? opiskeluoikeus)
             (log/info
               {:nayttotutkinto        true
-               :hoks-id               (:ehoks-id herate)
+               :hoks-id               (c/hoks-id herate)
                :request-id            uuid
                :opiskeluoikeus-oid    (:oid opiskeluoikeus)
                :koulutuksenjarjestaja koulutustoimija

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -26,7 +26,7 @@
              :tyyppi       (:kyselytyyppi herate)
              :alkupvm      (:alkupvm herate)
              :lahetystila  (:ei-lahetetty c/kasittelytilat)}]
-    (try (ehoks/add-kyselytunnus-to-hoks (:ehoks-id herate) req)
+    (try (ehoks/add-kyselytunnus-to-hoks (c/hoks-id herate) req)
          (catch Exception e
            (log/error e "Virhe kyselylinkin lähetyksessä eHOKSiin"
                       "Request:" req
@@ -105,7 +105,7 @@
                    alkupvm
                    loppupvm
                    (:odottaa-lahetysta c/kasittelytilat)
-                   (tutkinnonosat-by-hankkimistapa (:ehoks-id herate)))
+                   (tutkinnonosat-by-hankkimistapa (c/hoks-id herate)))
         arvo-resp (try (arvo/create-amis-kyselylinkki req-body)
                        (catch Exception e
                          (log/error e "Virhe kyselylinkin hakemisessa Arvosta."
@@ -150,7 +150,7 @@
                       " ja " (concat (when terminal? ["opiskeluoikeuden tilan"])
                                      (when ext-funded? ["rahoituspohjan"])))
                     "vuoksi; opiskeluoikeus" (:oid opiskeluoikeus)
-                    "ehoks-id" (:ehoks-id herate)
+                    "ehoks-id" (c/hoks-id herate)
                     "herätepvm" (:heratepvm herate))
           (update-and-return-herate!
             herate
@@ -235,7 +235,7 @@
           status (some-> kyselylinkki (arvo/get-kyselylinkki-status))]
       (cond
         (not kyselylinkki)
-        (log/warn "Hoksille" (:ehoks-id herate)
+        (log/warn "Hoksille" (c/hoks-id herate)
                   "ei ole kyselylinkkiä, ei voi lähettää")
 
         (not status)
@@ -251,7 +251,7 @@
           (update-data-in-ehoks herate lahetyspvm))
 
         :else
-        (do (log/info "Vastausaika loppunut hoksille" (:ehoks-id herate))
+        (do (log/info "Vastausaika loppunut hoksille" (c/hoks-id herate))
             (save-no-time-to-answer herate))))
     (catch Exception e
       (log/error e "at send-email-for-palaute! for" herate)

--- a/src/oph/heratepalvelu/amis/AMISherateHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateHandler.clj
@@ -53,7 +53,7 @@
 
         :else (ac/check-and-save-herate! herate opiskeluoikeus koulutustoimija
                                          (:ehoks herate-sources)))
-      (ac/update-herate-ehoks! (:ehoks-id herate) (:kyselytyyppi herate)))
+      (ac/update-herate-ehoks! (hoks-id herate) (:kyselytyyppi herate)))
     (catch JsonParseException e
       (log/error e "Virhe viestin lukemisessa:" (.getBody msg) "\n" e))
     (catch ExceptionInfo e

--- a/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
+++ b/src/oph/heratepalvelu/amis/UpdatedOpiskeluoikeusHandler.clj
@@ -118,7 +118,7 @@
             (do
               (ac/check-and-save-herate! herate opiskeluoikeus koulutustoimija
                                          (:koski herate-sources))
-              (ac/update-herate-ehoks! (:ehoks-id herate)
+              (ac/update-herate-ehoks! (hoks-id herate)
                                        (:kyselytyyppi herate)))))
         (catch ExceptionInfo e
           (if (= 404 (:status (ex-data e)))

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -32,6 +32,12 @@
                             (empty? (:sahkoposti %))))
                  "Aloituskyselyn herätteessä sahkoposti on pakollinen tieto"))
 
+(defn hoks-id
+  "Get hoks id from herate/item. This function is neccessary because
+  `:ehoks_id` was accidentally introduced on palaute-backend transition."
+  [item]
+  (or (:ehoks-id item) (:ehoks_id item)))
+
 (def kasittelytilat
   "Heräteviestien lähetyksien käsittelytilat."
   {:ei-lahetetty "ei_lahetetty"
@@ -121,13 +127,13 @@
                                   :tyyppi_kausi [:s tyyppi-kausi]})]
           (try
             (ehoks/add-kyselytunnus-to-hoks
-              (:ehoks-id item)
+              (hoks-id item)
               (assoc data
                      :alkupvm (:alkupvm item)
                      :tyyppi (:kyselytyyppi item)))
             (catch ExceptionInfo e
               (if (= 404 (:status (ex-data e)))
-                (log/warn "Ei hoksia " (:ehoks-id item))
+                (log/warn "Ei hoksia " (hoks-id item))
                 (throw e)))))
         (throw e)))))
 

--- a/src/oph/heratepalvelu/external/arvo.clj
+++ b/src/oph/heratepalvelu/external/arvo.clj
@@ -114,7 +114,7 @@
    :request_id                        request-id
    :toimipiste_oid                    (get-toimipiste suoritus)
    :hankintakoulutuksen_toteuttaja    (get-hankintakoulutuksen-toteuttaja
-                                        (:ehoks-id herate))
+                                        (c/hoks-id herate))
    :metatiedot                        {:tila initial-status}
    :tutkinnonosat_hankkimistavoittain tutkinnonosat})
 


### PR DESCRIPTION
## Kuvaus muutoksista

`:ehoks-id` -> `:ehoks_id` kentän nimenmuutoksella olikin sen verran vaikutusta, että tieto opiskelijapalautteiden tilasta ei tällä hetkellä synkronoidu Herätepalvelusta takaisin eHOKSiin. Tässä on toteutettu tuo simppeli korjaus, että käytetään jompaa kumpaa kentän nimeä, `:ehoks-id` tai `:ehoks_id`, riippuen kumpi on olemassa. Tää on tehty kaikkialle missä `:ehoks-id`-keywordia käytetään, riippumatta siitä onko kyseessä aktiivista tai kuollutta koodia.

https://jira.eduuni.fi/browse/EH-1816

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
