### PR TITLE
EH-1816: fix eHOKS kyselylinkki creation logic

### DIFF
--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -25,8 +25,11 @@
   (let [req {:kyselylinkki (:kyselylinkki herate)
              :tyyppi       (:kyselytyyppi herate)
              :alkupvm      (:alkupvm herate)
-             :lahetystila  (:ei-lahetetty c/kasittelytilat)}]
-    (try (ehoks/add-kyselytunnus-to-hoks (c/hoks-id herate) req)
+             :lahetystila  (:ei-lahetetty c/kasittelytilat)}
+        hoks-id (c/hoks-id herate)]
+    (try (log/info "Creating kyselytunnus in ehoks for hoks" hoks-id
+                   "with request" req)
+         (ehoks/add-kyselytunnus-to-hoks hoks-id req)
          (catch Exception e
            (log/error e "Virhe kyselylinkin lähetyksessä eHOKSiin"
                       "Request:" req

--- a/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
+++ b/src/oph/heratepalvelu/amis/AMISherateEmailHandler.clj
@@ -194,19 +194,14 @@
   "Päivittää sähköpostin tiedot ehoksiin, kun sähköposti on lähetetty
   viestintäpalveluun."
   [herate lahetyspvm]
-  (try
-    (update-lahetystila-to-ehoks herate lahetyspvm)
-    (catch ExceptionInfo e
-      (if (= 404 (:status (ex-data e)))
-        (try
-          (log/warn e "kyselylinkki missing, creating")
-          (update-kyselytunnus-in-ehoks! herate)
-          (update-lahetystila-to-ehoks herate lahetyspvm)
-          (catch Exception e
-            (log/error e "Virhe lähetystilan luomisessa ehoksiin")))
-        (log/error e "update-data-in-ehoks: Käsittelemätön virhe")))
-    (catch Exception e
-      (log/error e "update-data-in-ehoks: Käsittelemätön virhe"))))
+  (try (update-kyselytunnus-in-ehoks! herate)
+       (catch Exception e
+         (log/warn e "update-data-in-ehoks: kyselylinkki creation failed with"
+                   (ex-data e))))
+  (try (update-lahetystila-to-ehoks herate lahetyspvm)
+       (catch Exception e
+         (log/warn e "update-data-in-ehoks: kyselylinkki update failed with"
+                   (ex-data e)))))
 
 (defn send-feedback-email
   "Lähettää palautekyselyviestin viestintäpalveluun."

--- a/src/oph/heratepalvelu/common.clj
+++ b/src/oph/heratepalvelu/common.clj
@@ -119,29 +119,8 @@
 (defn send-lahetys-data-to-ehoks
   "Lähettää lähetyksen tiedot ehoksiin."
   [toimija-oppija tyyppi-kausi data]
-  (try
-    (ehoks/add-lahetys-info-to-kyselytunnus data)
-    (log/info "Patched lähetyksen tiedot:" toimija-oppija tyyppi-kausi data)
-    (catch ExceptionInfo e
-      (if (= 404 (:status (ex-data e)))
-        (let [item (ddb/get-item {:toimija_oppija [:s toimija-oppija]
-                                  :tyyppi_kausi [:s tyyppi-kausi]})]
-          (try
-            (ehoks/add-kyselytunnus-to-hoks
-              (hoks-id item)
-              (assoc data
-                     :alkupvm (:alkupvm item)
-                     :tyyppi (:kyselytyyppi item)))
-            (log/info "Created new kyselytunnus for hoks"
-                      (hoks-id item)
-                      (assoc data
-                             :alkupvm (:alkupvm item)
-                             :tyyppi  (:kyselytyyppi item)))
-            (catch ExceptionInfo e
-              (if (= 404 (:status (ex-data e)))
-                (log/warn "Ei hoksia " (hoks-id item))
-                (throw e)))))
-        (throw e)))))
+  (log/info "Patching lähetyksen tiedot:" toimija-oppija tyyppi-kausi data)
+  (ehoks/add-lahetys-info-to-kyselytunnus data))
 
 (defn date-string-to-timestamp
   "Muuttaa stringinä olevan päivämäärän timestampiksi (long)."

--- a/src/oph/heratepalvelu/external/ehoks.clj
+++ b/src/oph/heratepalvelu/external/ehoks.clj
@@ -2,6 +2,7 @@
   "Wrapperit eHOKSin REST-rajapinnan ympäri."
   (:require [cheshire.core :refer [generate-string]]
             [environ.core :refer [env]]
+            [clojure.tools.logging :as log]
             [oph.heratepalvelu.external.cas-client :as cas]
             [oph.heratepalvelu.external.http-client :as client])
   (:import (clojure.lang ExceptionInfo)))
@@ -94,6 +95,7 @@
                                    {:body (generate-string data)}))]
     (try (action)
          (catch ExceptionInfo e
+           (log/error e "while patching kyselylinkki with data" data)
            (if (not= 404 (:status (ex-data e)))
              (action)
              (throw e))))))

--- a/test/oph/heratepalvelu/integration_tests/amis/AMISherateEmailHandler_i_test.clj
+++ b/test/oph/heratepalvelu/integration_tests/amis/AMISherateEmailHandler_i_test.clj
@@ -29,6 +29,7 @@
     :sms-lahetystila [:s (:ei-lahetetty c/kasittelytilat)]
     :suorituskieli [:s "fi"]
     :kyselytyyppi [:s "aloittaneet"]
+    :ehoks-id [:n 939393]
     :alkupvm [:s "2022-01-01"]
     :heratepvm [:s "2022-01-01"]}
    {:toimija_oppija [:s "lkj/245"]
@@ -221,6 +222,7 @@
      :lahetyspvm [:s "2022-02-02"]
      :suorituskieli [:s "fi"]
      :kyselytyyppi [:s "aloittaneet"]
+     :ehoks-id [:n 939393]
      :alkupvm [:s "2022-01-01"]
      :heratepvm [:s "2022-01-01"]
      :viestintapalvelu-id [:n 123]}
@@ -298,6 +300,17 @@
     :url "arvo-example.com/vastauslinkki/v1/status/123"
     :options {:basic-auth ["arvo-user" "arvo-pwd"]
               :as :json}}
+   {:options
+    {:headers
+     {:ticket "service-ticket/ehoks-virkailija-backend/cas-security-check"},
+     :as :json,
+     :content-type "application/json",
+     :body (str "{\"kyselylinkki\":\"kysely.linkki/123\","
+                "\"tyyppi\":\"aloittaneet\","
+                "\"alkupvm\":\"2022-01-01\","
+                "\"lahetystila\":\"ei_lahetetty\"}")},
+    :url "ehoks-example.com/hoks/939393/kyselylinkki",
+    :method :post}
    {:method :patch
     :url "ehoks-example.com/hoks/kyselylinkki"
     :options {:headers {:ticket (str "service-ticket/ehoks-virkailija-backend"
@@ -381,6 +394,9 @@
                                                :kyselylinkki "kysely.linkki/123"
                                                :kyselytyyppi "aloittaneet"})}}
     :options {:as :json}}
+   {:type :get-service-ticket
+    :service "/ehoks-virkailija-backend"
+    :suffix "cas-security-check"}
    {:type :get-service-ticket
     :service "/ehoks-virkailija-backend"
     :suffix "cas-security-check"}


### PR DESCRIPTION
## Kuvaus muutoksista

Koodipolku, jolla kyselylinkki luodaan, muuttui sen takia että palaute-backendista työnnetään herätepalvelun kantaan herätteitä joissa on valmiiksi kyselylinkki.  Vanhastaan olemassa ollut (mutta ilmeisesti lähes käyttämätön) fallback-koodi `send-lahetys-data-to-ehoks`-funktiossa aktivoitui, mutta ei todennäköisesti ole koskaan ollut toimivaa koodia.  Tämä PR pyrkii tekemään POST .../kyselylinkki -kutsun samaan tapaan kuin se on tehty aikoinaan ja lisäämään vähän lokitusta _ennen_ virhetilanteita.

https://jira.eduuni.fi/browse/EH-1816

## Muistilista PR:n tekijälle ja katselmoijille

### Ennen asettamista katselmointiin
  - [ ] Build onnistuu ilman virheitä
  - [ ] Toiminnallisuuden kattavat yksikkötestit on tehty osana PR:ia
  - [ ] PR:n sisältämät muutokset noudattavat [sovittuja koodikäytänteitä](../doc/code-guidelines.md)
  - [ ] Koodi on riittävästi dokumentoitu tai se on muuten yksiselitteistä
  - [ ] Nimet (muuttujat, funktiot, ...) kuvaavat koodia hyvin

❗ **Katselmoijat tarkastavat, että yllä mainitut kohdat toteutuvat**

### Ennen mergeämistä `master`-haaralle
  - [ ] Vähintään yksi kehittäjä on katselmoinut ja hyväksynyt muutokset
    - Jos muutoksilla voi jotain rikkoessaan olla kauaskantoiset vaikutukset, kannattaa muutokset hyväksyttää useammalla katselmoijalla
  - [ ] Katselmoijien esittämät muutosehdotukset on huomioitu
  - [ ] Muutokset on testattu QA-ympäristössä
    - [ ] Testausohje kirjoitettu
    - [ ] Testaus delegoitu OPH:lle mikäli mahdollista
  - [ ] Yli jääneet kehityskohteet on tiketöity
